### PR TITLE
Revert "Updated repo location"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -116,7 +116,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/Cotalker/documentation/tree/master/',
+            'https://github.com/Cotalker/cotalker-doc/tree/master/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -116,7 +116,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/Cotalker/cotalker-doc/tree/master/',
+            'https://github.com/Cotalker/documentation/tree/main/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Reverts Cotalker/documentation#49

ERROR:

> Run npm run build
> 
> > cotalker@0.0.0 build /home/runner/work/documentation/documentation
> > docusaurus build
> 
> 
> [en] Creating an optimized production build...
> [Local Search] [INFO]: The documentation is not versioned (/home/runner/work/documentation/documentation/versions.json does not exist).
> [info] [webpackbar] Compiling Client
> [info] [webpackbar] Compiling Server
> [success] [webpackbar] Client: Compiled with some errors in 1.06m
> 
> 
> ./docs/documentation/automation/admin_cotlang.md
> SyntaxError: /home/runner/work/documentation/documentation/docs/documentation/automation/admin_cotlang.md: Expected corresponding JSX closing tag for <br> (25:155)
> ./docs/documentation/automation/admin_cotlang.md
> Module build failed (from ./node_modules/@docusaurus/mdx-loader/src/index.js):
> SyntaxError: /home/runner/work/documentation/documentation/docs/documentation/automation/admin_cotlang.md: Expected corresponding JSX closing tag for <br> (25:155)
> 
>   23 | <tr parentName="tbody">
>   24 | <td parentName="tr" {...{"align":null}}>{`Global Message Trigger`}</td>
> > 25 | <td parentName="tr" {...{"align":null}}><pre>{`{`}<br>{`  channel: COTChannel,`}<br>{`  message: COTMessage,`}<br>{`  cmdArgs: Array`}{`[string]`}<br>{`}`}</pre></td>
>      |                                                                                                                                                            ^
>   26 | <td parentName="tr" {...{"align":null}}>{`The source is a global bot that is trigger with a slash command.`}</td>
>   27 | </tr>
>   28 | <tr parentName="tbody">
>     at Object._raise (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:775:17)
>     at Object.raiseWithData (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:768:17)
>     at Object.raise (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:736:17)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5135:16)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElement (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5161:17)
>     at Object.parseExprAtom (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5168:19)
>     at Object.parseExprSubscripts (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:10668:23)
>  @ ./.docusaurus/registry.js 1:19345-19420 1:19191-19287
>  @ ./node_modules/@docusaurus/core/lib/client/exports/ComponentCreator.js
>  @ ./.docusaurus/routes.js
>  @ ./node_modules/@docusaurus/core/lib/client/clientEntry.js
>  @ multi ./node_modules/@docusaurus/core/lib/client/clientEntry.js
> 
>   23 | <tr parentName="tbody">
>   24 | <td parentName="tr" {...{"align":null}}>{`Global Message Trigger`}</td>
> > 25 | <td parentName="tr" {...{"align":null}}><pre>{`{`}<br>{`  channel: COTChannel,`}<br>{`  message: COTMessage,`}<br>{`  cmdArgs: Array`}{`[string]`}<br>{`}`}</pre></td>
>      |                                                                                                                                                            ^
>   26 | <td parentName="tr" {...{"align":null}}>{`The source is a global bot that is trigger with a slash command.`}</td>
>   27 | </tr>
>   28 | <tr parentName="tbody">
>  @ ./.docusaurus/registry.js 1:19345-19420 1:19191-19287
>  @ ./node_modules/@docusaurus/core/lib/client/exports/ComponentCreator.js
>  @ ./.docusaurus/routes.js
>  @ ./node_modules/@docusaurus/core/lib/client/clientEntry.js
>  @ multi ./node_modules/@docusaurus/core/lib/client/clientEntry.js
> Client bundle compiled with errors therefore further build is impossible.
> npm ERR! code ELIFECYCLE
> npm ERR! errno 1
> npm ERR! cotalker@0.0.0 build: `docusaurus build`
> npm ERR! Exit status 1
> npm ERR! 
> npm ERR! Failed at the cotalker@0.0.0 build script.
> npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
> 
> npm ERR! A complete log of this run can be found in:
> npm ERR!     /home/runner/.npm/_logs/2021-04-08T20_18_49_952Z-debug.log
> Error: Process completed with exit code 1.
