### PR TITLE
Revert "Contexts Update"

### DIFF
--- a/docs/documentation/automation/admin_cotlang.md
+++ b/docs/documentation/automation/admin_cotlang.md
@@ -14,41 +14,20 @@ It is used to extract data from different contexts in Cotalker. It is useful to 
 ## Context of the data {#context-of-the-data}
 This table contains the data to which the different sources have access. For example, if you are using cotlang in a survey trigger routine, you will have direct access to the task. <br/>
 
-| Source | Context | Notes |
-| ---- | --------- | ----  |
-| Global Message Trigger | <pre>{<br>  channel: COTChannel,<br>  message: COTMessage,<br>  cmdArgs: Array[string]<br>}</pre> | The source is a global bot that is trigger with a slash command. |
-| Channel Message Trigger	| <pre>{<br>  channel: COTChannel,<br>  message: COTMessage,<br>  cmdArgs: Array[string]<br>}</pre> | The source is a bot that is trigger with a slash command and is associated with particular channels. |	
-| Global Survey Trigger | 	<pre>{<br>  ...COTAnswer,<br>  messages: COTMessage,<br>}</pre>| Message have to be active to use. <br/> The source is a global bot that is trigger with a survey. |
-| Channe Survey Trigger	|	<pre>{<br>  ...COTAnswer,<br>  messages: COTMessage<br>}</pre>| Message have to be active to use. The source is a bot that is trigger with a survey and is associated with particular channels. |
-| SM SurveyTrigger	|	<pre>{<br>  ...COTTask,<br>  sentAnswer: COTAnswer<br>}</pre>|   |
-| SM Change State |	<pre>{<br>  ...COTTask<br>}</pre>| |
-| SM - New Subtask	|	<pre>{<br>  task: COTTask,<br>  parent: COTTask<br>}</pre>| |
-| SM - New Task	|	<pre>{<br>  task: COTTask,<br>  parent: COTTask<br>}</pre>| |
-| SLA	|	<pre>{<br>  taskId: ObjectId[COTTask]<br>  taskGroupId: ObjectId[COTTaskGroup]<br>}</pre>| |
-| Scheduler | <pre> custom body </pre>|	|	
-| SM - RequiredSurvey | <pre>{<br>  answer: COTAnswer,<br>  meta: {<br>    parentTask: ObjectId[COTTask],<br>    taskGroup: ObjectId[COTTaskGroup]<br>  }<br>}</pre>|
+| Source | Context | Format | Notes |
+| ---- | --------- | -------- | ------- |
+| Global Bot Message | channel: cotChannel - message: cotMessage - cmdArgs: Array string | { channel, message, cmdArgs } | The source is a global bot that is trigger with a slash command. |
+| Global Bot Answer | 	answer: cotAnswer	- messages: cotMessage | answer: { ..., messages, ... } | Message have to be active to use. <br/> The source is a global bot that is trigger with a survey. |
+| Channel Bot Message	| channel: CotChannel - message: CotMessage - cmdArgs: Array string | { channel, message, cmdArgs } | Message have to be active to use. <br/> The source is a bot that is trigger with a slash command and is associated with particular channels. |	
+| Channel Bot Answer	|	answer: CotAnswer	- messages: cotMessage | answer: { ..., messages, ... } | Message have to be active to use. The source is a bot that is trigger with a survey and is associated with particular channels. |
+| SM SurveyTrigger	|	task: CotTask	- sentAnswer: CotAnswer | task: {..., sentAnswer: {...}, ...} |   |
+| SM Change State |	task: CotTask |	task: {...} | |
+| SM - New Subtask	|	task: CotTask - parent 	| { task, parent } | |
+| SM - New Task	|	task: CotTask - parent	| { task, parent } | |
+| SLA	|	taskId: Object Id - taskGroupId: Object id	| { taskId, taskGroupId } | |
+| Scheduler | null | null |	|	
+| SM - RequiredSurvey | { answer, meta: { parentTask, taskGroup } } | |
  
- ### Context language description {#context-language}
-1. `...` Destructuring Operator: each key is merged into the parent object.
-For example:
-```
-if COTExample is { _id: ObjectId, content: String } 
-then             { ...COTExample,                  someKeyName: Number } 
-represents       { _id: ObjectId, content: String, someKeyName: Number }
-```
-2. Array[T]: is an array of type T.
-For example:
-```
-model       { commands: Array[String] }
-can contain { commands: ["hello", "world"] } 
-```
-3. [COTChannel Data model](/docs/documentation/api/communication/channels)
-4. [COTMessage Data model](/docs/documentation/api/communication/messages)
-5. [COTAnswer Data model](/docs/documentation/api/surveys/answers)
-6. [COTTask Data model](/docs/documentation/api/tasks/tasks) 
-7. [COTTaskGroup Data model](/docs/documentation/api/tasks/task_groups)
-8. ObjectID[T]: 24-character unique identifier that represents an object of type T
-
 
 ## How to use Cotlang {#how-to-use-cotlang}
 To configure the type of stages, COTlang is useful to easily get information from the database.


### PR DESCRIPTION
Reverts Cotalker/documentation#52

ERROR:

> Run npm run build
> 
> > cotalker@0.0.0 build /home/runner/work/documentation/documentation
> > docusaurus build
> 
> 
> [en] Creating an optimized production build...
> [Local Search] [INFO]: The documentation is not versioned (/home/runner/work/documentation/documentation/versions.json does not exist).
> [info] [webpackbar] Compiling Client
> [info] [webpackbar] Compiling Server
> [success] [webpackbar] Client: Compiled with some errors in 1.06m
> 
> 
> ./docs/documentation/automation/admin_cotlang.md
> SyntaxError: /home/runner/work/documentation/documentation/docs/documentation/automation/admin_cotlang.md: Expected corresponding JSX closing tag for <br> (25:155)
> ./docs/documentation/automation/admin_cotlang.md
> Module build failed (from ./node_modules/@docusaurus/mdx-loader/src/index.js):
> SyntaxError: /home/runner/work/documentation/documentation/docs/documentation/automation/admin_cotlang.md: Expected corresponding JSX closing tag for <br> (25:155)
> 
>   23 | <tr parentName="tbody">
>   24 | <td parentName="tr" {...{"align":null}}>{`Global Message Trigger`}</td>
> > 25 | <td parentName="tr" {...{"align":null}}><pre>{`{`}<br>{`  channel: COTChannel,`}<br>{`  message: COTMessage,`}<br>{`  cmdArgs: Array`}{`[string]`}<br>{`}`}</pre></td>
>      |                                                                                                                                                            ^
>   26 | <td parentName="tr" {...{"align":null}}>{`The source is a global bot that is trigger with a slash command.`}</td>
>   27 | </tr>
>   28 | <tr parentName="tbody">
>     at Object._raise (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:775:17)
>     at Object.raiseWithData (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:768:17)
>     at Object.raise (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:736:17)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5135:16)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElementAt (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5103:32)
>     at Object.jsxParseElement (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5161:17)
>     at Object.parseExprAtom (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:5168:19)
>     at Object.parseExprSubscripts (/home/runner/work/documentation/documentation/node_modules/@babel/parser/lib/index.js:10668:23)
>  @ ./.docusaurus/registry.js 1:19345-19420 1:19191-19287
>  @ ./node_modules/@docusaurus/core/lib/client/exports/ComponentCreator.js
>  @ ./.docusaurus/routes.js
>  @ ./node_modules/@docusaurus/core/lib/client/clientEntry.js
>  @ multi ./node_modules/@docusaurus/core/lib/client/clientEntry.js
> 
>   23 | <tr parentName="tbody">
>   24 | <td parentName="tr" {...{"align":null}}>{`Global Message Trigger`}</td>
> > 25 | <td parentName="tr" {...{"align":null}}><pre>{`{`}<br>{`  channel: COTChannel,`}<br>{`  message: COTMessage,`}<br>{`  cmdArgs: Array`}{`[string]`}<br>{`}`}</pre></td>
>      |                                                                                                                                                            ^
>   26 | <td parentName="tr" {...{"align":null}}>{`The source is a global bot that is trigger with a slash command.`}</td>
>   27 | </tr>
>   28 | <tr parentName="tbody">
>  @ ./.docusaurus/registry.js 1:19345-19420 1:19191-19287
>  @ ./node_modules/@docusaurus/core/lib/client/exports/ComponentCreator.js
>  @ ./.docusaurus/routes.js
>  @ ./node_modules/@docusaurus/core/lib/client/clientEntry.js
>  @ multi ./node_modules/@docusaurus/core/lib/client/clientEntry.js
> Client bundle compiled with errors therefore further build is impossible.
> npm ERR! code ELIFECYCLE
> npm ERR! errno 1
> npm ERR! cotalker@0.0.0 build: `docusaurus build`
> npm ERR! Exit status 1
> npm ERR! 
> npm ERR! Failed at the cotalker@0.0.0 build script.
> npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
> 
> npm ERR! A complete log of this run can be found in:
> npm ERR!     /home/runner/.npm/_logs/2021-04-08T20_18_49_952Z-debug.log
> Error: Process completed with exit code 1.