### PR TITLE
docs(cli): partner-facing cotctl CLI section (EN + ES)

### DIFF
--- a/docs/developer/cli/ai-authoring.md
+++ b/docs/developer/cli/ai-authoring.md
@@ -1,0 +1,92 @@
+---
+title: AI-assisted authoring (Skills & RAG)
+sidebar_label: AI-assisted authoring
+displayed_sidebar: developer
+---
+
+So far this guide has treated `cotctl` as a tool *you* drive by hand. But `cotctl` is also the foundation for something bigger: **authoring Cotalker configurations with the help of an AI agent.** This page explains how that ecosystem fits together — and why it makes you, as a partner, dramatically faster.
+
+## The idea in one picture
+
+Writing resource YAML by hand is precise but slow, and it's easy to forget a field or a naming convention. An AI agent like **Claude Code** can write that YAML for you — *if* it knows two things: how Cotalker resources are structured, and what actually exists in the platform right now. `cotctl` provides exactly those two things, through **Skills** and **RAG**:
+
+```
+              Claude Code  (the AI agent)
+                    │   writes the YAML for you
+        ┌───────────┴────────────┐
+        │                        │
+     SKILLS                   RAG (via MCP)
+ cotctl skills install     cotctl mcp install
+ → domain expertise:       → live grounding:
+   how each resource          up-to-date Cotalker
+   is authored                documentation
+        └───────────┬────────────┘
+                    ▼
+   correct YAML → cotctl validate → cotctl apply
+```
+
+- **Skills** teach the agent *how* to write each kind of resource (a survey, a workflow, a role…), encoding Cotalker's conventions so the output is well-formed.
+- **RAG** (through an MCP server) grounds the agent in the *current* Cotalker documentation, so it answers from real reference material instead of guessing field names.
+
+Put together, you describe what you want in plain language, the agent produces grounded YAML, and you finish with the same trustworthy `validate` → `apply` loop you already know.
+
+## The three pieces
+
+### 1. The agent
+
+[Claude Code](https://claude.com/claude-code) is the AI coding assistant that does the authoring. On its own it's a capable generalist; the next two pieces turn it into a Cotalker specialist.
+
+### 2. Skills — domain expertise, installed
+
+A **Skill** is an installable package that gives the agent specialized knowledge and tools for one area. `cotctl` ships a set of them — one per resource type — that you install with a single command:
+
+```bash
+cotctl skills install
+```
+
+Once installed, asking the agent to "create a purchase-orders workflow" produces YAML that follows Cotalker's structure and naming conventions, because the relevant Skill is guiding it. The full command reference — listing, scopes, and the available Skills — is on the [Skills](./skills.md) page.
+
+### 3. RAG — live documentation grounding
+
+**RAG** (Retrieval-Augmented Generation) lets the agent look things up in Cotalker's documentation as it works, via an **MCP** server. This is what stops it from inventing a field that doesn't exist: when it's unsure, it retrieves the real reference. You connect it with:
+
+```bash
+cotctl mcp install
+```
+
+Conveniently, installing the Skills already offers to set this up for you. The full details — indices, scopes, multiple servers — are on the [MCP integration](./mcp-integration.md) page.
+
+## The authoring loop, end to end
+
+Here's what working this way actually looks like:
+
+```bash
+# 1. One-time setup: install the Skills (this also offers to connect the RAG/MCP)
+cotctl skills install --all
+
+# 2. In Claude Code, describe what you want in plain language, e.g.:
+#    "Scaffold a purchase-orders workflow with draft, pending, approved
+#     and rejected states, and a manager role with full access."
+#    → the agent writes the YAML, grounded by the Skills + RAG.
+
+# 3. You stay in control with the usual safety loop:
+cotctl validate --dir ordenes-compra/
+cotctl apply    --dir ordenes-compra/ -c dev
+cotctl validate --workflow ordenes_compra -c dev
+```
+
+<div className="alert alert--primary">
+
+**You're always the reviewer.** The agent drafts; you validate and apply. Nothing reaches an environment without going through `cotctl validate` and your explicit `apply`. The AI makes authoring faster — it doesn't remove the guardrails.
+
+</div>
+
+## Why this matters for partners
+
+This is the difference between *configuring Cotalker* and *implementing on Cotalker at speed*. The Skills carry the conventions so you don't have to memorize them, the RAG keeps everything current as the platform evolves, and `cotctl` remains the trustworthy way to validate and ship what the agent produces. The result is faster delivery with the same — or better — correctness.
+
+## Next steps
+
+- [**Skills**](./skills.md) — install and manage the Cotalker Skills for Claude Code
+- [**MCP integration**](./mcp-integration.md) — connect the documentation RAG
+- [**Tutorials**](./tutorials.md) — the resource flows the agent helps you author

--- a/docs/developer/cli/authentication.md
+++ b/docs/developer/cli/authentication.md
@@ -112,14 +112,15 @@ acme          https://www.cotalker.com         acme         admin@acme.com
 devteam       https://staging.cotalker.com     devteam      dev@cotalker.com
 ```
 
-**Remove one.** When you no longer need an environment, delete its profile. This removes it from your local file — it does **not** invalidate the token on the server:
+**Remove one.** When you no longer need an environment, log out of it. For modern API-token profiles this **revokes the token on the server** and then removes the local profile:
 
 ```bash
 cotctl logout acme
+# Remote ApiToken revoked.
 # Logged out from profile "acme".
 ```
 
-`cotctl profile delete <name>` does the same thing, with a confirmation prompt.
+If you only want to forget a profile locally **without** revoking its token, use `cotctl profile delete <name>` instead.
 
 ## You don't have to think about token refresh
 

--- a/docs/developer/cli/authentication.md
+++ b/docs/developer/cli/authentication.md
@@ -1,0 +1,140 @@
+---
+title: Authentication
+sidebar_label: Authentication
+displayed_sidebar: developer
+---
+
+Now that `cotctl` is installed, it needs to know *which Cotalker environment to talk to* and *who you are*. This page explains how authentication works, walks you through your first login, and introduces **profiles** — the concept that lets you safely juggle several environments.
+
+## How cotctl thinks about authentication: profiles
+
+`cotctl` stores your credentials in a **profiles** system, kept in a file at `~/.cotctl/config.json`. Each profile holds the connection details and token for one environment or company.
+
+This matters because as a partner you'll often work with more than one company — a staging environment, a production environment, several customers. Instead of logging in and out constantly, you log in *once per environment*, each login becomes a named profile, and from then on you simply tell each command which profile to use.
+
+<div className="alert alert--primary">
+
+**Good to know.** There is no `.env` file and no hardcoded token to copy around. Everything lives in the managed profiles file, which `cotctl` creates with restrictive permissions. You never paste a token by hand.
+
+</div>
+
+## Your first login
+
+To connect to an environment, use `cotctl login`. The most important detail: the `--url` flag takes the **webclient URL** — the address you'd open in a browser to use Cotalker — *not* an API URL. `cotctl` figures out the API address automatically from there.
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain acme
+```
+
+By default this opens your browser to log in. Here's what happens, step by step:
+
+1. `cotctl` opens your browser on the environment's authorization page.
+2. You log in (if you aren't already) and approve access.
+3. The token is transferred back to the CLI automatically.
+4. A profile is saved to `~/.cotctl/config.json` — named `acme` in this example, after the `--subdomain`.
+
+If the browser doesn't open on its own, `cotctl` prints the URL in the terminal so you can open it manually.
+
+### Logging in without a browser
+
+On a server, in CI, or any headless environment where no browser is available, add `--no-browser` to log in with email and password instead:
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain acme --no-browser
+```
+
+```
+Email: admin@acme.com
+Password: ********
+
+Logged in as admin@acme.com (company: 64a1b2c3...)
+Profile saved as "acme"
+Use with: cotctl surveys list -c acme
+```
+
+### All login options
+
+| Option | Description |
+|---|---|
+| `--url <url>` | **(required)** Webclient URL of the environment |
+| `--subdomain <name>` | **(required)** Subdomain or company name |
+| `--api-url <url>` | API URL, if you need to override autodiscovery |
+| `--no-browser` | Use email/password instead of the browser flow |
+| `--profile <name>` | Custom profile name (defaults to the `--subdomain` value) |
+
+## The `-c` flag: telling commands which company to act on
+
+This is the single most important habit to build. **Every command that touches the API requires a `-c` (or `--company`) flag** naming the profile to use. There is deliberately no default — this prevents you from accidentally running a command against the wrong customer's environment.
+
+```bash
+cotctl surveys list -c acme
+cotctl apply -f survey.yaml -c acme
+cotctl surveys export my_survey -c acme
+```
+
+If you forget it, `cotctl` stops and tells you:
+
+```
+Error: --company/-c is required. Use 'cotctl profile list' to see available profiles.
+```
+
+That error is a feature, not a nuisance: it's the guardrail that keeps a staging change from landing in production.
+
+## Working with multiple environments
+
+Because each login is its own profile, supporting several environments is just several logins:
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain acme
+cotctl login --url https://web.staging.cotalker.com --subdomain devteam
+cotctl login --url https://www.cotalkercoopeuch.com --subdomain coopeuch
+```
+
+After that, switching environments is simply a matter of changing the `-c` value:
+
+```bash
+cotctl surveys list -c acme
+cotctl surveys list -c devteam
+cotctl apply -f survey.yaml -c coopeuch
+```
+
+## Managing your profiles
+
+**See what you have.** To list every profile you've saved:
+
+```bash
+cotctl profile list
+```
+
+```
+NAME          URL                              SUBDOMAIN    USER
+acme          https://www.cotalker.com         acme         admin@acme.com
+devteam       https://staging.cotalker.com     devteam      dev@cotalker.com
+```
+
+**Remove one.** When you no longer need an environment, delete its profile. This removes it from your local file — it does **not** invalidate the token on the server:
+
+```bash
+cotctl logout acme
+# Logged out from profile "acme".
+```
+
+`cotctl profile delete <name>` does the same thing, with a confirmation prompt.
+
+## You don't have to think about token refresh
+
+Tokens expire, but `cotctl` handles renewal for you before each API call, so in normal use you rarely log in more than once a week:
+
+- **Less than 50 minutes old:** used as-is.
+- **Between 50 minutes and 7 days old:** renewed quietly in the background.
+- **Older than 7 days:** the session has expired and you'll be asked to log in again.
+
+If a refresh can't be done, `cotctl` tells you exactly what to run:
+
+```
+Error: Session expired for profile "acme". Run: cotctl login --url https://web.cotalker.com --subdomain acme
+```
+
+## Next step
+
+You're connected. Now let's put it to work — head to [**Commands**](./commands/apply.md) to learn `apply`, the verb you'll use most.

--- a/docs/developer/cli/ci-cd.md
+++ b/docs/developer/cli/ci-cd.md
@@ -1,0 +1,97 @@
+---
+title: CI/CD pipelines
+sidebar_label: CI/CD
+displayed_sidebar: developer
+---
+
+Everything `cotctl` does on your laptop, it can do unattended in a pipeline. Running it in CI/CD is what turns "a partner deploys changes by hand" into "changes are validated and deployed automatically on every merge" — repeatable, reviewable, and not dependent on anyone remembering the steps. This page shows the recommended shape and, importantly, how to handle credentials safely.
+
+## The recommended pipeline shape
+
+A good `cotctl` pipeline mirrors the manual workflow: **validate on every change, apply on merge.**
+
+1. **On a pull request** — run `cotctl validate --dir` (offline, no credentials needed). This catches schema and cross-reference errors before review.
+2. **On merge to your main branch** — run `cotctl apply --dir -c <profile>` against the target environment, optionally preceded by a `--dry-run`.
+
+Because every apply is idempotent, re-running the deploy is always safe.
+
+## Handling credentials safely
+
+This is the part to get right. In a pipeline there's no browser to log in with, so you authenticate non-interactively — but **you never put a token in your repository**.
+
+<div className="alert alert--primary">
+
+**The rule: secrets live in your CI provider, never in code.** Store the credentials as encrypted CI secrets (GitHub Actions secrets, GitLab CI variables, etc.) and read them from environment variables at runtime. Never commit a token, and never paste one into a YAML or script that's checked in.
+
+</div>
+
+There are two ways to authenticate in CI, depending on what your environment supports:
+
+**Option A — log in with `--no-browser` using secret credentials.** The cleanest approach when you have a service account with email/password:
+
+```bash
+cotctl login \
+  --url https://web.cotalker.com \
+  --subdomain acme \
+  --no-browser
+# credentials supplied via the CI secret-backed environment variables
+```
+
+**Option B — provide a token via a secret.** If you mint a token out-of-band, expose it to the job as a secret-backed environment variable (for example `$COTCTL_TOKEN`) rather than hardcoding it. Reference the variable; never the literal value.
+
+## A worked example (GitHub Actions)
+
+This workflow validates on pull requests and deploys on pushes to `main`. The credentials come entirely from repository secrets:
+
+```yaml
+name: Deploy Cotalker config
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm install -g @cotctl/cli
+      # Offline — no credentials required
+      - run: cotctl validate --dir config/
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: validate
+    runs-on: ubuntu-latest
+    env:
+      COTCTL_EMAIL: ${{ secrets.COTCTL_EMAIL }}
+      COTCTL_PASSWORD: ${{ secrets.COTCTL_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm install -g @cotctl/cli
+      - run: cotctl login --url https://web.cotalker.com --subdomain acme --no-browser
+      - run: cotctl apply --dir config/ -c acme -y
+```
+
+Note `cotctl apply ... -y` — the `-y` flag skips the interactive confirmation prompts, which is exactly what you want in an unattended job.
+
+## Token lifetime in CI
+
+Tokens expire after 7 days of inactivity. For pipelines that run regularly this is rarely an issue, but for infrequent deploys, prefer a **service account** and re-authenticate at the start of each run rather than caching a token between runs.
+
+## Use `--continue-on-error` deliberately
+
+By default, a directory apply stops at the first failure — usually what you want, so a broken deploy halts loudly. Add `--continue-on-error` only when you intentionally want the remaining entities to apply despite one failing.
+
+## See also
+
+- [validate](./commands/validate.md) — the offline gate to run on every PR
+- [apply](./commands/apply.md) — `--dir`, `--dry-run`, and `-y`
+- [Authentication](./authentication.md) — how login and profiles work

--- a/docs/developer/cli/ci-cd.md
+++ b/docs/developer/cli/ci-cd.md
@@ -25,19 +25,21 @@ This is the part to get right. In a pipeline there's no browser to log in with, 
 
 </div>
 
-There are two ways to authenticate in CI, depending on what your environment supports:
+Both `cotctl login` (browser) and `cotctl login --no-browser` (email/password) are **interactive** — they open a browser or prompt for credentials — so they aren't suitable for an unattended job on their own. The reliable way to authenticate in CI is with a **pre-generated API token**.
 
-**Option A — log in with `--no-browser` using secret credentials.** The cleanest approach when you have a service account with email/password:
+**1. Generate the token once.** An administrator issues an API token from the Cotalker admin panel (or the Partner Platform) and you store its value as an encrypted CI secret — for example `COTCTL_API_TOKEN`.
+
+**2. Authenticate non-interactively with `--paste-token`.** `cotctl login --paste-token` creates a profile from a pre-generated token instead of prompting for credentials. In CI, pipe the secret into it:
 
 ```bash
-cotctl login \
+echo "$COTCTL_API_TOKEN" | cotctl login \
   --url https://web.cotalker.com \
   --subdomain acme \
-  --no-browser
-# credentials supplied via the CI secret-backed environment variables
+  --profile acme \
+  --paste-token
 ```
 
-**Option B — provide a token via a secret.** If you mint a token out-of-band, expose it to the job as a secret-backed environment variable (for example `$COTCTL_TOKEN`) rather than hardcoding it. Reference the variable; never the literal value.
+Nothing is hardcoded, and there's no interactive prompt to hang on.
 
 ## A worked example (GitHub Actions)
 
@@ -68,15 +70,14 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     env:
-      COTCTL_EMAIL: ${{ secrets.COTCTL_EMAIL }}
-      COTCTL_PASSWORD: ${{ secrets.COTCTL_PASSWORD }}
+      COTCTL_API_TOKEN: ${{ secrets.COTCTL_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
       - run: npm install -g @cotctl/cli
-      - run: cotctl login --url https://web.cotalker.com --subdomain acme --no-browser
+      - run: echo "$COTCTL_API_TOKEN" | cotctl login --url https://web.cotalker.com --subdomain acme --profile acme --paste-token
       - run: cotctl apply --dir config/ -c acme -y
 ```
 

--- a/docs/developer/cli/commands/apply.md
+++ b/docs/developer/cli/commands/apply.md
@@ -1,0 +1,183 @@
+---
+title: apply
+sidebar_label: apply
+displayed_sidebar: developer
+---
+
+`cotctl apply` is the command that actually changes a Cotalker environment. It takes your YAML and makes the platform match it — creating resources that don't exist and updating those that do. This is the verb you'll use most, so it's worth understanding well.
+
+There are two ways to run it, depending on whether you're deploying one file or a whole folder:
+
+| Mode | Flag | Purpose |
+|---|---|---|
+| Single file | `-f <file>` | Apply one YAML file of any supported kind |
+| Directory | `--dir <path>` | Apply every YAML file in a folder, in the correct dependency order |
+
+<div className="alert alert--primary">
+
+**Always validate first.** `apply` writes to a real environment. Make `cotctl validate` (and `--dry-run`) part of your muscle memory before every apply — especially against production.
+
+</div>
+
+## How apply decides what to do
+
+`apply` reads the `kind:` field at the top of your YAML and routes to the right handler. Seven kinds are supported:
+
+| `kind:` | What it manages |
+|---|---|
+| `Survey` | Forms |
+| `AccessRole` | Permissions |
+| `PropertyType` | Data model schemas |
+| `Property` | Data model instances |
+| `JobTitle` | Org positions (Cargos) |
+| `Workflow` | Processes and state machines |
+| `User` | People |
+
+If `kind:` is missing or unrecognized, `apply` stops and lists the valid options (plus the entity-scoped form for each, like `cotctl roles apply`). It never guesses.
+
+**Create vs. update is automatic.** `apply` looks the resource up by its `code` (or `name`). If it doesn't exist, it's created; if it does, it's updated. You don't choose — you just describe the desired state.
+
+## Single-file mode
+
+```bash
+cotctl apply -f <file.yaml> -c <profile> [options]
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `-f, --file <path>` | **(required)** Path to the YAML file |
+| `-c, --company <profile>` | **(required)** Profile to use |
+| `--dry-run` | Validate and show what *would* be sent, without applying |
+| `-y, --yes` | Skip confirmation prompts (warnings still print to stderr) |
+| `--skip-semantic-validation` | **Survey only** — skip semantic checks |
+| `--skip-remote-validation` | **Survey only** — skip remote checks |
+
+### Examples
+
+```bash
+# Create or update a survey
+cotctl apply -f my-survey.yaml -c acme
+
+# Preview what would be sent — changes nothing
+cotctl apply -f my-survey.yaml -c acme --dry-run
+
+# A workflow, a role, a property type — same command, different kind
+cotctl apply -f workflow.yaml -c acme
+cotctl apply -f role.yaml -c acme
+cotctl apply -f property-type.yaml -c acme
+```
+
+A successful apply confirms what happened:
+
+```
+Survey "my_survey" created successfully (id: 507f1f77bcf86cd799439011)
+```
+
+<div className="alert alert--info">
+
+**You never manage IDs by hand.** When creating, you don't include `_id`/`id` — the backend generates them. When updating, `cotctl` retrieves the existing resource and resolves the right IDs for you (matching survey questions by their `identifier`). Your YAML stays clean and human-readable.
+
+</div>
+
+### What you can change on a survey update
+
+Because questions are matched by `identifier`, not position, edits behave intuitively:
+
+| You want to… | Do this | Result |
+|---|---|---|
+| Add a question | Add it to `questions[]` | Created |
+| Remove a question | Delete it from `questions[]` | Deactivated (not hard-deleted), after a confirmation prompt |
+| Edit a question | Change its fields, keep the `identifier` | Updated, ID preserved |
+| Reorder questions | Reorder `questions[]` | Order changes, IDs preserved |
+
+Two things are immutable once created: a survey's `code`, and a question's `identifier`. `apply` will refuse to rename either — to "rename", you create a new resource instead. And if you apply a survey YAML without its `questions` section (say, to toggle `isActive`), the existing questions are preserved automatically.
+
+## Directory mode
+
+For anything beyond a single file — and especially for a scaffolded workflow, which spans roles, property types, properties, and the workflow itself — point `apply` at the folder and let it handle ordering:
+
+```bash
+cotctl apply --dir <path> -c <profile> [options]
+```
+
+### Why order matters (and why you don't have to think about it)
+
+Resources depend on each other: a workflow references roles and property types, which must exist first. `apply --dir` groups documents by kind and applies them in this canonical order automatically:
+
+| # | Entity | Comes first because… |
+|---|---|---|
+| 1 | AccessRole | Everything else references permissions |
+| 2 | PropertyType | Foundation of the data model |
+| 3 | Property | Depends on PropertyType |
+| 4 | JobTitle | Depends on roles and the data model |
+| 5 | Workflow | References roles, property types, and properties |
+| 6 | Survey | Referenced by workflow transitions |
+| 7 | User | Depends on job titles and roles |
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--dir <path>` | **(required)** Folder of YAML files |
+| `-c, --company <profile>` | **(required)** Profile to use |
+| `--dry-run` | Preview every payload without applying |
+| `-y, --yes` | Skip all confirmation prompts |
+| `--continue-on-error` | Keep going if one entity fails (default: stop on first error) |
+
+### Example
+
+```bash
+# Preview, then apply
+cotctl apply --dir ordenes-compra/ -c dev --dry-run
+cotctl apply --dir ordenes-compra/ -c dev
+```
+
+```
+Applying directory: ordenes-compra/ → dev
+
+AccessRole (6 documents)
+  ✓ created  ordenes-compra:start-form
+  ...
+PropertyType (3 documents)
+  ✓ created  oc_transaccion
+  ...
+Workflow (1 document)
+  ✓ created  ordenes_compra
+
+─────────────────────────────────────────────────────────────────
+13 created, 0 updated, 0 errors
+```
+
+### It's safe to run twice
+
+Directory apply is **idempotent** — re-running it is expected and safe:
+
+| Scenario | Behavior |
+|---|---|
+| Fresh environment | Everything created |
+| Re-apply, no changes | Everything updated (effectively a no-op) |
+| Re-apply with new files | Existing updated, new created |
+| State removed from a workflow YAML | **Blocked** — missing states are rejected |
+| Immutable field changed | **Blocked** — `code`/`nameCode` immutability enforced |
+
+## A word on rate limits and permissions
+
+The backend rate-limits writes (roughly 20 per 5-second window). In large batch scripts, space out your calls or handle `429` responses. And if any apply returns `403`, the logged-in user lacks the required administration permission — that's a Cotalker permissions matter, not a CLI one.
+
+## The standard loop
+
+In practice, deploying a workflow looks like this:
+
+```bash
+cotctl validate --dir ordenes-compra/            # 1. catch errors offline
+cotctl apply    --dir ordenes-compra/ -c dev     # 2. deploy
+cotctl validate --workflow ordenes_compra -c dev # 3. production-readiness check
+```
+
+## See also
+
+- [validate](./validate.md) — always run before apply
+- [scaffolding](./scaffolding.md) — generate the folder that `apply --dir` consumes
+- [Resource YAML reference](../resources/surveys.md) — the schema for each kind

--- a/docs/developer/cli/commands/export-import.md
+++ b/docs/developer/cli/commands/export-import.md
@@ -1,0 +1,116 @@
+---
+title: Exporting & importing
+sidebar_label: Export & import
+displayed_sidebar: developer
+---
+
+So far we've talked about pushing YAML *to* an environment. Just as often, you'll want to pull existing configuration *out* of one — to bring a customer's existing setup under version control, to copy a resource between environments, or simply to see how something is built. That round-trip — **export → edit → apply** — is one of the most useful patterns in `cotctl`.
+
+This page uses surveys as the worked example, because they have the richest export options. The same `list` / `get` / `export` / `apply` shape repeats across the other entity groups (`roles`, `property-types`, `properties`, `users`, `jobtitles`, `workflows`).
+
+<div className="alert alert--info">
+
+**Naming note.** The old `cotctl get surveys` and `cotctl export survey` commands were removed. Use the entity-scoped forms — `cotctl surveys list`, `cotctl surveys export`, and so on.
+
+</div>
+
+## Finding what's there: `list`
+
+Before exporting, you usually need to find the resource. `list` shows what exists, with search and paging:
+
+```bash
+cotctl surveys list -c acme
+```
+
+```
+ID                         NAME                  CODE             VER   ACTIVE   MODIFIED
+-------------------------------------------------------------------------------------------
+507f1f77bcf86cd799439011   Order Request Form    order_request    3     true     2024-03-15
+507f1f77bcf86cd799439012   Approval Survey       approval_srv      1     true     2024-02-20
+```
+
+Useful options: `-s/--search <text>` to filter by name or code, `--all` to include inactive resources, `-l/--limit` and `-p/--page` for paging, and `--json` for machine-readable output.
+
+## Looking at one: `get`
+
+To inspect a single resource without writing a file:
+
+```bash
+cotctl surveys get order_request -c acme
+```
+
+Add `--populate` to include the full question list (output switches to YAML automatically, since a table can't show nested questions), or `-o json` to get JSON.
+
+## Pulling it out: `export`
+
+`export` is what brings a resource down as a YAML file you can version and re-apply:
+
+```bash
+cotctl surveys export order_request -c acme -o ./order_request.yaml
+```
+
+<div className="alert alert--secondary">
+
+**`-o` is a path, not a format.** A common first mistake is `-o yaml`. The `-o`/`--output` flag is the *file path* to write to; use `--format` to choose the format. Passing a format keyword to `-o` is a hard error with a message telling you exactly this.
+
+</div>
+
+Two export formats are available:
+
+| `--format` | Description |
+|---|---|
+| `simplified` (default) | Human-readable, with a clean `questions[]` array — what you want for version control |
+| `raw` | The raw API representation |
+
+```bash
+# Default simplified YAML, printed to stdout
+cotctl surveys export order_request -c acme
+
+# Raw format, written to a file
+cotctl surveys export order_request -c acme --format raw -o ./order_request_raw.yaml
+```
+
+### Keeping scripts out of YAML
+
+Surveys can carry inline JavaScript (exec hooks). For cleaner version control, `--extract-scripts <dir>` pulls those scripts out into separate files and replaces them with `file://` references in the YAML:
+
+```bash
+cotctl surveys export order_request -c acme \
+  -o ./order_request.yaml \
+  --extract-scripts ./scripts/
+```
+
+Now the JavaScript lives in real `.js` files your editor and Git can handle properly.
+
+## The round-trip in full
+
+Putting it together, the export–edit–apply loop looks like this:
+
+```bash
+# 1. Export the live resource
+cotctl surveys export order_request -c acme -o order_request.yaml
+
+# 2. Edit order_request.yaml in your editor, commit it to Git
+
+# 3. Validate, then apply the change back
+cotctl validate -f order_request.yaml
+cotctl apply -f order_request.yaml -c acme
+```
+
+This is also how you **promote between environments** — export from staging, apply to production (with the matching `-c` profile).
+
+## Deactivating instead of deleting
+
+Cotalker favors deactivation over hard deletion. To take a survey out of use without losing it:
+
+```bash
+cotctl surveys deactivate order_request -c acme
+```
+
+It sets `isActive: false` after a confirmation prompt (`-y` skips the prompt in scripts).
+
+## See also
+
+- [apply](./apply.md) — the other half of the round-trip
+- [validate](./validate.md) — check exported YAML before re-applying
+- [Resource YAML reference](../resources/surveys.md) — what the exported files contain

--- a/docs/developer/cli/commands/login-logout.md
+++ b/docs/developer/cli/commands/login-logout.md
@@ -1,0 +1,87 @@
+---
+title: login & logout
+sidebar_label: login & logout
+displayed_sidebar: developer
+---
+
+These two commands open and close your connection to a Cotalker environment. If you've already read the [Authentication](../authentication.md) page, you've met `login` — this page is the complete reference for both commands, including every option and the less common cases like on-premise environments.
+
+## `cotctl login`
+
+`login` authenticates you against a Cotalker environment and saves the result as a reusable **profile** in `~/.cotctl/config.json`. You typically run it once per environment.
+
+```bash
+cotctl login --url <webclient-url> --subdomain <subdomain> [options]
+```
+
+The key thing to remember: `--url` is the **webclient** address (what you'd type into a browser), not an API URL. `cotctl` discovers the API automatically from it.
+
+### Options
+
+| Option | Required | Default | Description |
+|---|---|---|---|
+| `--url` | Yes | — | Webclient URL of the environment |
+| `--subdomain` | Yes | — | Company subdomain |
+| `--api-url` | No | Auto-detected | Manual override of the API URL |
+| `--no-browser` | No | `false` | Use email/password instead of the browser flow |
+| `--profile` | No | Value of `--subdomain` | Custom profile name |
+
+### Browser flow (the default)
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain acme
+```
+
+This opens your browser on the Cotalker authentication page, you approve access, and the token is handed back to the CLI. The flow times out after 5 minutes if you don't complete it.
+
+### Email/password flow
+
+When there's no browser available — a server, a CI runner — add `--no-browser` and you'll be prompted for credentials in the terminal:
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain acme --no-browser
+```
+
+### On-premise environments
+
+Most environments expose a variables file that lets `cotctl` auto-discover the API URL. If a customer runs Cotalker on their own infrastructure and that discovery fails, point `cotctl` at the API explicitly with `--api-url`:
+
+```bash
+cotctl login \
+  --url https://cotalker.empresa.com \
+  --subdomain emp \
+  --api-url https://api.empresa.com
+```
+
+<div className="alert alert--info">
+
+**Where credentials live.** The profile is written to `~/.cotctl/config.json` with restrictive file permissions (`0600`). There's no token to copy or store yourself.
+
+</div>
+
+### A note on permissions
+
+To apply resources (surveys, workflows, and so on) you need administration permissions in Cotalker. If a command later returns a `403`, that's the platform telling you the logged-in user lacks the required permission — ask the company's administrator to grant it.
+
+## `cotctl logout`
+
+`logout` removes a profile's credentials from your local config file.
+
+```bash
+cotctl logout <profile>
+# or, equivalently:
+cotctl logout -c <profile>
+```
+
+The positional `<profile>` is optional if you pass `-c <profile>` instead.
+
+<div className="alert alert--secondary">
+
+**Important nuance.** `logout` only removes the profile *locally* — it does **not** invalidate the token on the Cotalker server. It is equivalent to [`cotctl profile delete`](./profiles.md). To actually revoke a token server-side, do so from the Cotalker web interface.
+
+</div>
+
+## See also
+
+- [Authentication](../authentication.md) — the conceptual walkthrough of profiles and the `-c` flag
+- [Managing profiles](./profiles.md) — list and delete saved profiles

--- a/docs/developer/cli/commands/login-logout.md
+++ b/docs/developer/cli/commands/login-logout.md
@@ -77,7 +77,7 @@ The positional `<profile>` is optional if you pass `-c <profile>` instead.
 
 <div className="alert alert--secondary">
 
-**Important nuance.** `logout` only removes the profile *locally* — it does **not** invalidate the token on the Cotalker server. It is equivalent to [`cotctl profile delete`](./profiles.md). To actually revoke a token server-side, do so from the Cotalker web interface.
+**`logout` revokes your token server-side.** For modern API-token profiles, `cotctl logout` **revokes the ApiToken on the Cotalker server** and then removes the local profile, so the token can no longer be used. (Legacy JWT profiles have nothing to revoke — they simply expire — so they're only removed locally.) This is the key difference from [`cotctl profile delete`](./profiles.md), which removes the profile **locally only** and leaves any token valid.
 
 </div>
 

--- a/docs/developer/cli/commands/profiles.md
+++ b/docs/developer/cli/commands/profiles.md
@@ -32,7 +32,7 @@ cotctl profile delete <name>
 
 <div className="alert alert--secondary">
 
-**Local only.** Deleting a profile removes it from `~/.cotctl/config.json` but does **not** invalidate the token on the server — exactly like [`cotctl logout`](./login-logout.md). The two commands are equivalent. To revoke a token server-side, use the Cotalker web interface.
+**Local only — this does *not* revoke the token.** Deleting a profile removes it from `~/.cotctl/config.json` but leaves any token valid on the server. This is different from [`cotctl logout`](./login-logout.md), which revokes the ApiToken server-side (for API-token profiles) before removing the profile. Use `profile delete` when you just want to forget a profile; use `logout` when you also want to invalidate its token.
 
 </div>
 

--- a/docs/developer/cli/commands/profiles.md
+++ b/docs/developer/cli/commands/profiles.md
@@ -1,0 +1,49 @@
+---
+title: Managing profiles
+sidebar_label: profile
+displayed_sidebar: developer
+---
+
+A **profile** is a saved connection to one Cotalker environment — created every time you run [`cotctl login`](./login-logout.md). As a partner working across staging, production, and several customers, you'll accumulate a few of them. The `cotctl profile` command is how you see and tidy up that list.
+
+## `cotctl profile list`
+
+Shows every profile you've saved, with the environment and user behind each one:
+
+```bash
+cotctl profile list
+```
+
+```
+NAME          URL                              SUBDOMAIN    USER
+acme          https://www.cotalker.com         acme         admin@acme.com
+devteam       https://staging.cotalker.com     devteam      dev@cotalker.com
+```
+
+This is the command to reach for whenever you're unsure which profile name to pass to `-c`, or you want to confirm which user a profile is authenticated as.
+
+## `cotctl profile delete`
+
+Removes a profile from your local config file:
+
+```bash
+cotctl profile delete <name>
+```
+
+<div className="alert alert--secondary">
+
+**Local only.** Deleting a profile removes it from `~/.cotctl/config.json` but does **not** invalidate the token on the server — exactly like [`cotctl logout`](./login-logout.md). The two commands are equivalent. To revoke a token server-side, use the Cotalker web interface.
+
+</div>
+
+## The `-c` flag, one more time
+
+Every command that talks to the API requires `-c <profile>` to select which environment to act on — there is no default, on purpose. `cotctl profile list` is how you find the exact name to use:
+
+```bash
+cotctl apply -f survey.yaml -c staging
+cotctl surveys list -c production
+cotctl surveys export my_survey -c staging
+```
+
+If you ever see `Error: --company/-c is required`, run `cotctl profile list` to pick the right name.

--- a/docs/developer/cli/commands/scaffolding.md
+++ b/docs/developer/cli/commands/scaffolding.md
@@ -1,0 +1,95 @@
+---
+title: Scaffolding a workflow
+sidebar_label: Scaffolding
+displayed_sidebar: developer
+---
+
+Building a workflow from a blank file is a lot of boilerplate: you need roles, property types, state properties, and the workflow itself, all named consistently and wired together. `cotctl workflows scaffold` generates that skeleton for you — correctly named and ready to customize — so you start from a working structure instead of an empty page.
+
+It's an offline command. No environment is touched until you `apply` later.
+
+## The command
+
+```bash
+cotctl workflows scaffold --name <flow-name> --code <prefix> [options]
+```
+
+Two inputs are required:
+
+- `--name` — the flow name in kebab-case, e.g. `ordenes-compra`.
+- `--code` — a short 2–4 letter prefix used across all generated codes, e.g. `oc`.
+
+```bash
+cotctl workflows scaffold --name ordenes-compra --code oc
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--name <name>` | **(required)** Flow name, kebab-case |
+| `--code <prefix>` | **(required)** 2–4 lowercase letters |
+| `--display <name>` | Human-readable name (default: title-cased `--name`) |
+| `--output-dir <dir>` | Where to write (default: `./<name>/`) |
+| `--states <list>` | Extra closed states beyond the base three, comma-separated |
+| `--no-technical` | Omit the technical permissions (`form-bypass`, `force-state`) |
+
+## What it generates
+
+A scaffold is a small folder of YAML, organized by concern:
+
+```
+ordenes-compra/
+├── README.md                  # Flow definition, naming conventions, apply order
+├── workflow.yaml              # Workflow + state machine + transitions
+├── access/
+│   ├── permissions.yaml       # One AccessRole per permission
+│   └── manager-role.yaml      # Manager role aggregating all permissions
+└── data-model/
+    ├── property-types.yaml    # transaccion, maestro, estados
+    └── states.yaml            # base states: borrador, pendiente, error
+```
+
+Out of the box you get six access roles (four with `--no-technical`), a Manager role, three property types, three base states (a *new* state, an *in-progress* state, and an *error* state), and one workflow with its state machine. Everything follows Cotalker's implementation naming conventions, so the result passes the nomenclature checks in [`cotctl validate --workflow`](./validate.md#workflow-mode--production-readiness-online) from the start.
+
+### Adding your own states
+
+Most real flows need more than the three base states. Pass them with `--states` and `cotctl` generates the state properties and wires transitions from `pendiente` to each:
+
+```bash
+cotctl workflows scaffold --name ordenes-compra --code oc \
+  --display "Órdenes de Compra" \
+  --states aprobado,rechazado,cerrado
+```
+
+## The pipeline it fits into
+
+Scaffolding is step 1 of a five-step loop. Steps 2–5 repeat safely as you iterate, because every apply is idempotent:
+
+```
+1. scaffold   →  cotctl workflows scaffold --name ordenes-compra --code oc
+2. customize  →  edit the YAML — add properties, forms, business logic
+3. validate   →  cotctl validate --dir ordenes-compra/
+4. apply      →  cotctl apply --dir ordenes-compra/ -c dev
+5. validate   →  cotctl validate --workflow ordenes_compra -c dev
+```
+
+<div className="alert alert--primary">
+
+**The mental model.** Scaffold gives you a *correct skeleton*. You then flesh it out (step 2), check it offline (step 3), deploy it (step 4), and confirm it's production-ready against the live environment (step 5) — looping over 2–5 until you're happy.
+
+</div>
+
+## A couple of input rules
+
+`cotctl` validates your inputs up front so the generated names are always valid:
+
+- `--name` must be kebab-case (e.g. `ordenes-compra`).
+- `--code` must be 2–4 lowercase letters.
+- `--output-dir` must not already exist (so you never overwrite work).
+
+## See also
+
+- [validate](./validate.md) — check the scaffold offline, then against the live workflow
+- [apply](./apply.md) — deploy the whole folder with `--dir`
+- [Workflows YAML reference](../resources/workflows.md) — understand what you're customizing

--- a/docs/developer/cli/commands/validate.md
+++ b/docs/developer/cli/commands/validate.md
@@ -1,0 +1,120 @@
+---
+title: validate
+sidebar_label: validate
+displayed_sidebar: developer
+---
+
+`cotctl validate` checks your YAML *before* you deploy it. Getting into the habit of validating first is one of the highest-value things you can do as a partner: it catches mistakes on your machine, in seconds, instead of as a half-applied change in a customer's environment.
+
+There are three things you might want to validate, and `validate` has a mode for each:
+
+| Mode | Flag | Network | What it's for |
+|---|---|---|---|
+| File | `-f <file>` | Offline | Check a single Survey YAML file |
+| Directory | `--dir <path>` | Offline | Cross-check a whole folder of resources before `apply --dir` |
+| Workflow | `--workflow <nameCode>` | Online | Run the production-readiness checklist against a live workflow |
+
+## File mode — one survey, offline
+
+The quickest check. Validates a single Survey YAML against the schema, with no API call:
+
+```bash
+cotctl validate -f my-survey.yaml
+```
+
+```
+✓ my-survey.yaml is valid
+```
+
+If something's wrong, it tells you what and where:
+
+```
+✗ my-survey.yaml has validation errors:
+
+  - code: code must start with a lowercase letter and contain only lowercase letters, numbers, and underscores
+```
+
+Under the hood, three layers of checking run:
+
+| Layer | What it checks | How to skip |
+|---|---|---|
+| Structure (Zod) | Types, required fields, enums | Always on |
+| Semantic | `function run()` in exec hooks, buttons in the wrong stage, deprecated fields | `--skip-semantic-validation` |
+| Remote | Identifier uniqueness across the company, that referenced entities exist | Needs `--remote` + `-c <profile>` |
+
+The first two are offline. Remote checks reach the API, so they require a profile:
+
+```bash
+cotctl validate -f my-survey.yaml --remote -c acme
+```
+
+## Directory mode — a whole folder, offline
+
+This is the one you'll use most when working with scaffolded workflows. It validates every YAML file in a folder **and** checks that they reference each other correctly — all offline. Run it right before `apply --dir`:
+
+```bash
+cotctl validate --dir ordenes-compra/
+```
+
+It runs two families of checks. **Schema checks**, per file:
+
+| ID | Check |
+|---|---|
+| S1 | File parses as valid YAML |
+| S2 | `kind` is present and recognized |
+| S3 | Document validates against the schema for its `kind` |
+
+And **cross-reference checks**, across files — this is what catches a property pointing at a property type that doesn't exist:
+
+| ID | Severity | Check |
+|---|---|---|
+| X1 | warn | Permission strings (`name:action`) are defined as AccessRoles |
+| X2 | fail | `Property.propertyType` references an existing PropertyType |
+| X3 | fail | Workflow state machine `propertyType` references resolve |
+| X4 | fail | Workflow `states[].property` references an existing Property |
+| X5 | fail | The state machine `initialState` references an existing Property |
+| X6 | warn | Workflow permissions are defined as AccessRoles |
+
+A clean run ends with a clear verdict:
+
+```
+Results: 11 PASS, 0 WARN, 0 FAIL — ready to apply
+```
+
+Add `--json` if you want to consume the result in a script.
+
+## Workflow mode — production readiness, online
+
+Once a workflow is live, this mode runs the **Marcha Blanca** (go-live) checklist against it. It's an online check, so it needs a profile:
+
+```bash
+cotctl validate --workflow ordenes_compra -c prod
+```
+
+The checklist is organized in three sections, and you can run just one with `--section`:
+
+- **Nomenclature** (`nomenclature`) — naming conventions for codes, forms, properties, and permissions.
+- **Permissions** (`permissions`) — that a Manager role exists with all flow permissions, wired into the linked forms.
+- **Configuration** (`configuration`) — technical rules, like control fields being read-only and an error state existing.
+
+```bash
+# only the naming checks
+cotctl validate --workflow ordenes_compra --section nomenclature -c prod
+```
+
+```
+Results: 13 PASS, 1 WARN, 0 FAIL — production ready
+```
+
+Checks are graded **WARN** (a recommendation) or **FAIL** (a real problem). The command exits `0` when everything passes or only warns, and `1` when at least one check fails — which is exactly what you want as a gate in a pipeline.
+
+<div className="alert alert--info">
+
+**A couple of known limits.** Deep JavaScript code-quality checks on exec hooks aren't implemented, and the error-state check (T3) looks for the `_estado_error` naming convention — if your implementation names its error state differently, expect a warning even when an error state exists.
+
+</div>
+
+## See also
+
+- [apply](./apply.md) — deploy your resources once validation passes
+- [scaffolding](./scaffolding.md) — generate a workflow skeleton to validate and apply

--- a/docs/developer/cli/demo-company.md
+++ b/docs/developer/cli/demo-company.md
@@ -1,0 +1,73 @@
+---
+title: Practice in a demo company first
+sidebar_label: Demo company
+displayed_sidebar: developer
+---
+
+Before you point `cotctl` at a real customer's environment, do yourself a favor: **practice in a demo company first.** This single habit is the best way to learn the tool with zero risk — your first real use case should never be a production company.
+
+## Why this matters
+
+`cotctl apply` makes real changes to a real environment. While you're still learning — getting comfortable with profiles, the validate → apply loop, scaffolding a workflow, seeing what an error looks like — you want a place where mistakes cost nothing. A **demo company** is exactly that: a throwaway environment where you can experiment freely, break things, start over, and build confidence before any of it touches a live customer.
+
+<div className="alert alert--primary">
+
+**The rule of thumb.** Your *first* end-to-end run of any new flow — and your *first* time using `cotctl` at all — should happen in a demo or sandbox company, never in production. Graduate to real environments only once the steps are second nature.
+
+</div>
+
+## Getting a demo company
+
+New companies are created through the **Cotalker Partner Platform** — the super-admin web application for managing organizations across the Cotalker ecosystem, where creating and configuring a new company is a built-in capability.
+
+- **If you have super-user access to the Partner Platform**, create a fresh demo company there and use it as your sandbox.
+- **If you don't**, ask your Cotalker contact to provision a demo/sandbox company for you. For partner onboarding this is often ideal, since it can be pre-seeded to resemble a real implementation.
+
+Either way, the goal is the same: a non-production company you fully control.
+
+## Connecting cotctl to it
+
+Once you have a demo company, log into it just like any other environment — it simply becomes another profile. Giving it an obvious name (like `demo`) makes it hard to confuse with a customer's environment later:
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain my-demo --profile demo
+```
+
+From then on, everything you practice runs against `-c demo`:
+
+```bash
+cotctl validate --dir ordenes-compra/
+cotctl apply    --dir ordenes-compra/ -c demo
+cotctl validate --workflow ordenes_compra -c demo
+```
+
+<div className="alert alert--info">
+
+**The `-c` flag is your safety net.** Because every command requires you to name the company explicitly, the only way a change reaches production is if you *type* a production profile. Keeping a clearly-named `demo` profile makes the safe choice the obvious one. See [Authentication](./authentication.md) for how profiles work.
+
+</div>
+
+## A suggested first run
+
+A great way to break in your demo company is to do the full workflow recipe end to end — generate a scaffold, validate it, apply it, and run the production-readiness check — all against `-c demo`:
+
+```bash
+cotctl workflows scaffold --name ordenes-compra --code oc --display "Órdenes de Compra"
+cotctl validate --dir ordenes-compra/
+cotctl apply    --dir ordenes-compra/ -c demo
+cotctl validate --workflow ordenes_compra -c demo
+```
+
+Nothing here can hurt a customer — so experiment, inspect the result in the demo company's UI, tweak the YAML, and re-apply as many times as you like.
+
+## Graduating to real environments
+
+Once you're comfortable, real work is the same commands with a different profile. A healthy progression is:
+
+**demo → staging → production** — prove a change in your demo company, promote it to a customer's staging environment, and only then to production. The [export & import](./commands/export-import.md) flow is how you carry the same YAML across those environments.
+
+## Next steps
+
+- [Tutorials](./tutorials.md) — run these in your demo company first
+- [Authentication](./authentication.md) — profiles and the `-c` flag
+- [apply](./commands/apply.md) — what actually changes an environment

--- a/docs/developer/cli/installation.md
+++ b/docs/developer/cli/installation.md
@@ -1,0 +1,82 @@
+---
+title: Installation
+sidebar_label: Installation
+displayed_sidebar: developer
+---
+
+In this page you'll get `cotctl` installed on your machine and confirm it's working. It takes about two minutes. If you've ever installed a global npm package before, this will feel familiar.
+
+## Before you start: the requirements
+
+There are two things you need in place:
+
+- **Node.js version 22.0.0 or newer.** `cotctl` is distributed as an npm package and runs on Node. To check whether you have it — and which version — run:
+
+  ```bash
+  node --version
+  ```
+
+  If the command isn't found, or the number is lower than `22`, install or upgrade Node first from [nodejs.org](https://nodejs.org). We recommend the LTS release.
+
+- **Administrator access to the Cotalker company you want to manage.** Most `cotctl` commands read and write configuration, which requires admin permissions on the target environment.
+
+<div className="alert alert--info">
+
+**Don't have admin access yet?** That's fine for installing the tool — you can do everything on this page without it. But you'll need it before the [Authentication](./authentication.md) step, so it's worth requesting from the company's Cotalker administrator now.
+
+</div>
+
+## Installing the tool
+
+The recommended way is to install it **globally**, which makes the `cotctl` command available everywhere on your machine:
+
+```bash
+npm install -g @cotctl/cli
+```
+
+The `-g` flag is what makes it global. After this finishes, you can run `cotctl` from any folder.
+
+### Prefer not to install globally?
+
+If you only need it occasionally, or you want to pin a version per project, you can run it on demand with `npx` — this downloads and runs it without a permanent install:
+
+```bash
+npx @cotctl/cli <command> [options]
+```
+
+Throughout this guide we'll write commands as `cotctl ...`. If you're using `npx`, just replace that with `npx @cotctl/cli ...`.
+
+## Confirming it worked
+
+Let's make sure the install succeeded. Ask the tool for its version:
+
+```bash
+cotctl --version
+```
+
+You should see a version number printed back, for example:
+
+```
+0.8.0
+```
+
+If you see a version, you're done — the tool is installed correctly. If instead you get a "command not found" error, the global npm bin directory may not be on your `PATH`; the [Troubleshooting](./troubleshooting.md) page covers how to fix that.
+
+## Getting your bearings
+
+Two commands are worth knowing from the start. The general shape of every `cotctl` invocation is:
+
+```bash
+cotctl <command> [options]
+```
+
+And whenever you're unsure what's available or what a command expects, append `--help`:
+
+```bash
+cotctl --help            # list all commands
+cotctl apply --help      # options for a specific command
+```
+
+## Next step
+
+`cotctl` is installed, but it doesn't know about any Cotalker environment yet. Let's fix that in [**Authentication**](./authentication.md), where you'll connect it to a company and learn how profiles work.

--- a/docs/developer/cli/mcp-integration.md
+++ b/docs/developer/cli/mcp-integration.md
@@ -1,0 +1,59 @@
+---
+title: MCP & AI integration
+sidebar_label: MCP integration
+displayed_sidebar: developer
+---
+
+`cotctl` can connect AI assistants — like Claude — to Cotalker's technical documentation, so that while you're authoring resources you can ask questions and get answers grounded in the real, up-to-date docs. This page explains the idea and how to set it up.
+
+## What is MCP, and why would a partner care?
+
+**MCP** (Model Context Protocol) is a standard way to give an AI assistant access to an external source of knowledge or tools. Cotalker exposes an MCP server backed by its documentation, so an assistant connected to it can answer "how do I structure a workflow transition?" or "what fields does a property type take?" using the actual reference material instead of guessing.
+
+For a partner authoring YAML, that means faster, more accurate help right inside your editor or AI tool — fewer round-trips to the docs, fewer invented field names.
+
+## Registering the server
+
+The simplest path is the managed command, which walks you through connecting and lets you pick which documentation sets to include:
+
+```bash
+cotctl mcp install
+```
+
+<div className="alert alert--info">
+
+**Where's the endpoint?** The MCP endpoint URL is specific to your Cotalker environment — your Cotalker contact can provide it. `cotctl mcp install` handles the connection details for you, so the managed command is the recommended route.
+
+</div>
+
+If you prefer to register it manually with an MCP-capable client, the shape is an HTTP transport pointing at the documentation endpoint:
+
+```bash
+# Replace the URL with your environment's documentation MCP endpoint
+claude mcp add --transport http cotalker-docs https://<your-cotalker-docs-endpoint>/mcp
+```
+
+## Focusing on specific documentation
+
+A single endpoint can serve several documentation sets ("indices"). You can scope a connection to just the ones you care about with an `?indices=` query parameter — for example, to query only the CLI docs:
+
+```bash
+claude mcp add --transport http cotalker-cli \
+  "https://<your-cotalker-docs-endpoint>/mcp?indices=cotctl"
+```
+
+You can also register **multiple** servers, each scoped to a different set — one for the CLI, another for the API and data models — so the assistant routes each question to the most relevant source:
+
+```bash
+claude mcp add --transport http cotalker-cli \
+  "https://<your-cotalker-docs-endpoint>/mcp?indices=cotctl"
+claude mcp add --transport http cotalker-api \
+  "https://<your-cotalker-docs-endpoint>/mcp?indices=cot-api,cot-models"
+```
+
+Each registered server advertises what it covers, which is how the assistant decides where to look.
+
+## See also
+
+- [Overview](./overview.md) — what `cotctl` is and how the pieces fit together
+- [Resource YAML reference](./resources/surveys.md) — the docs the MCP server makes queryable

--- a/docs/developer/cli/overview.md
+++ b/docs/developer/cli/overview.md
@@ -1,0 +1,88 @@
+---
+title: Cotalker CLI (cotctl)
+sidebar_label: Overview
+displayed_sidebar: developer
+---
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import Highlight from '@theme/Highlight';
+
+<span className="hero__title">Cotalker CLI — cotctl</span>
+<br/>
+<br/>
+
+_Welcome! This guide will take you from zero to deploying your first Cotalker configuration from the command line. It's written for **implementation partners** — the technical consultants and developers who build solutions on top of Cotalker — and it assumes no prior experience with the CLI._
+
+## What is cotctl, and why would you use it?
+
+When you configure Cotalker through the web admin panel, you click through forms to create surveys, workflows, roles, and so on. That works well for one-off changes, but it has limits: changes aren't versioned, they're hard to reproduce across environments, and you can't automate them.
+
+`cotctl` solves this. It is a **command-line tool that manages Cotalker resources declaratively from YAML files** — much like `kubectl` manages Kubernetes, or like Terraform manages cloud infrastructure. Instead of clicking, you *describe* the resource you want in a text file, and `cotctl` makes the platform match that description.
+
+In practice, this gives you four things that matter when you're delivering projects for customers:
+
+- **Declarative.** You write *what you want* (a survey with these questions, a workflow with these states), and `cotctl apply` figures out whether to create or update it. You don't manage the "how".
+- **Versionable.** Your YAML lives in your own Git repository. Every change a customer's configuration goes through is reviewable in a pull request and reversible with a `git revert`.
+- **Reproducible.** The exact same files deploy to a staging environment first and to production later, against any company you have access to. No more "it worked in the demo".
+- **Automatable.** Because it's a command, it runs unattended in a CI/CD pipeline — so deployments become repeatable and don't depend on someone remembering the steps.
+
+<div className="alert alert--primary">
+
+**The mental model.** A Cotalker company is a collection of *resources* (surveys, workflows, properties, roles, users…). With `cotctl` you keep a YAML description of those resources in Git, and you `apply` them to an environment. The YAML is the source of truth; the environment is the result.
+
+</div>
+
+## What you can manage with it
+
+Almost every building block you assemble during an implementation has a `cotctl` representation:
+
+| Resource | What it is | Command group |
+|---|---|---|
+| **Surveys** | Forms used to capture data | `cotctl surveys`, `cotctl apply` |
+| **Workflows** | Processes and their state machines | `cotctl workflows`, `cotctl workflows scaffold` |
+| **Property types & properties** | The data model (entities and their fields) | `cotctl property-types`, `cotctl properties` |
+| **Access roles** | Permissions and what each role can see/do | `cotctl roles` |
+| **Users** | People in the company, with their hierarchy | `cotctl users` |
+| **Job titles (Cargos)** | Organizational positions | `cotctl jobtitles` |
+
+Don't worry about learning all of these at once. Most partners start with surveys and workflows and pick up the rest as projects require them.
+
+## A 60-second taste
+
+Here is the shortest possible path from nothing to a deployed change. We'll explain each step in detail in the next pages — this is just so you can see the shape of it:
+
+```bash
+# 1. Install the tool (once per machine)
+npm install -g @cotctl/cli
+
+# 2. Connect it to an environment. This saves a reusable "profile" called acme.
+cotctl login --url https://web.cotalker.com --subdomain acme
+
+# 3. Deploy a resource. The -c flag tells cotctl which company to act on.
+cotctl apply -f my-survey.yaml -c acme
+```
+
+That's the whole loop: **install → login → apply.** Everything else in this guide makes each of those steps more powerful and safer.
+
+## How this guide is organized
+
+We recommend reading the first three pages in order — they get you set up and productive:
+
+1. [**Installation**](./installation.md) — get `cotctl` onto your machine and confirm it works.
+2. [**Authentication**](./authentication.md) — connect to an environment and understand profiles and the all-important `-c` flag.
+3. [**Practice in a demo company**](./demo-company.md) — set up a safe, non-production environment so your first real use case isn't a customer's live company.
+4. [**Commands**](./commands/apply.md) — the day-to-day verbs: `apply`, `validate`, exporting/importing, and scaffolding.
+
+Then reach for these as you need them:
+
+- [**Resource YAML reference**](./resources/surveys.md) — the exact schema for each resource type.
+- [**Tutorials**](./tutorials.md) — complete, end-to-end recipes you can follow along with.
+- [**Troubleshooting**](./troubleshooting.md) — what the common errors mean and how to fix them.
+- [**CI/CD**](./ci-cd.md) — running `cotctl` in automated pipelines.
+
+<div className="alert alert--secondary">
+
+**A note on exit codes.** `cotctl` returns `0` when everything succeeded and `1` on any error (a validation problem, an API error, a missing profile, or a missing file). You don't need this yet, but it's what makes `cotctl` safe to use in scripts and CI gates later on.
+
+</div>
+
+Ready? Let's [install it](./installation.md).

--- a/docs/developer/cli/overview.md
+++ b/docs/developer/cli/overview.md
@@ -3,8 +3,6 @@ title: Cotalker CLI (cotctl)
 sidebar_label: Overview
 displayed_sidebar: developer
 ---
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import Highlight from '@theme/Highlight';
 
 <span className="hero__title">Cotalker CLI — cotctl</span>
 <br/>

--- a/docs/developer/cli/resources/jobtitles.md
+++ b/docs/developer/cli/resources/jobtitles.md
@@ -1,0 +1,83 @@
+---
+title: Job titles (YAML)
+sidebar_label: Job titles
+displayed_sidebar: developer
+---
+
+A **job title** (Cargo) is the bridge between a person and what they can do. It links a [user](./users.md) to a set of [access roles](./roles.md), property-type extensions, and inherited properties. Assign a user a job title, and they inherit everything the job title grants. Because job titles depend on roles and the data model, they're applied after those — and before users.
+
+## The shape of a job title
+
+```yaml
+kind: JobTitle
+code: store_manager
+display: "Jefe de Tienda"
+isActive: true
+accessRoles:
+  - "ordenes-compra:manager"
+  - "ventas:reader"
+allowedExtensions:
+  - "perfil_jefe"
+elements:
+  - "elemento_inventario_default"
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `kind` | Yes | Always `JobTitle` |
+| `code` | Yes | Unique per company, 3–50 chars, lowercase/underscores. **Immutable after creation** |
+| `display` | Yes | Human-readable label (mutable) |
+| `isActive` | No | Defaults to `true` |
+| `accessRoles` | No | AccessRole **names** (case-sensitive), max 50 |
+| `allowedExtensions` | No | PropertyType **codes**, max 50 |
+| `elements` | No | Property **codes** inherited by users |
+
+The three list fields each reference a different resource by name or code:
+
+- **`accessRoles`** → role names the user inherits.
+- **`allowedExtensions`** → property *types* a user may attach as a profile extension.
+- **`elements`** → specific *properties* (e.g. a default location) the user inherits.
+
+<div className="alert alert--primary">
+
+**These lists are REPLACE-on-update, not merge.** When you update a job title, the array you send *replaces* the one on the server. Omit a role that was already there, and it's removed. Always export before a partial edit:
+
+```bash
+cotctl jobtitles export store_manager -c acme -o store_manager.yaml
+```
+
+</div>
+
+<div className="alert alert--info">
+
+**Role names are case-sensitive.** `cotctl` matches `accessRoles` exactly. If a name isn't found, the error includes a "did you mean…?" suggestion — usually a casing slip. List the real names with `cotctl roles list -c <profile>`.
+
+</div>
+
+## Renaming
+
+Like several resources, `code` is immutable, and there's no in-place rename for job titles. To change a code: deactivate the old one, create a new one, then re-point the affected users with `cotctl users apply` setting their `job` to the new code.
+
+## Deactivation and reactivation
+
+Deactivate with the dedicated command (or `isActive: false` in YAML):
+
+```bash
+cotctl jobtitles deactivate store_manager -c acme
+```
+
+Reactivating is deliberately guarded: applying `isActive: true` to a currently-inactive job title requires the explicit `--allow-reactivate` flag, so you never bring one back by accident.
+
+## Apply job titles before users
+
+<div className="alert alert--secondary">
+
+**Order matters here for a subtle reason.** If you apply a user whose `job` code doesn't yet exist as a job title, the backend may silently create a placeholder job title — often malformed or inactive — which then breaks later user applies. Applying job titles first avoids this entirely, and `cotctl apply --dir` enforces the order for you.
+
+</div>
+
+## See also
+
+- [Roles](./roles.md), [Property types](./properties.md) — what a job title references
+- [Users](./users.md) — reference job titles via `job`
+- [apply](../commands/apply.md) — job titles are applied fourth, before users

--- a/docs/developer/cli/resources/properties.md
+++ b/docs/developer/cli/resources/properties.md
@@ -1,0 +1,128 @@
+---
+title: Property types & properties (YAML)
+sidebar_label: Properties & types
+displayed_sidebar: developer
+---
+
+Cotalker's data model is built from two related resources: **property types** and **properties**. Understanding the relationship between them is the key to the whole model, so let's start there.
+
+## The mental model: type vs. instance
+
+A **property type** is a *schema* — it defines the shape of something, like "a Location has an address, a city, and a country." A **property** is an *instance* of that schema — like "Santiago, at Av. Providencia 1234, in Chile."
+
+If you've worked with databases, a property type is the table definition and a property is a row. You define the type once, then create as many properties of that type as you need.
+
+Because properties depend on their type, the type must exist first — and `cotctl apply --dir` enforces exactly that order (property types before properties).
+
+## Property types
+
+A property type declares a `code`, a `display` name, and a list of `schemaNodes` (its fields):
+
+```yaml
+kind: PropertyType
+code: location
+display: Location
+hidden: true
+schemaNodes:
+  - key: address
+    display: Address
+    basicType: string
+    validators:
+      required: true
+  - key: city
+    display: City
+    basicType: string
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `kind` | Yes | Always `PropertyType` |
+| `code` | Yes | Unique per company. **Immutable after creation** |
+| `display` | Yes | UI display name |
+| `hidden` | No | Defaults to `true`. See below |
+| `viewPermissions` | Conditional | AccessRole names. **Required when `hidden: false`** |
+| `schemaNodes` | No | The field definitions |
+
+### Visible vs. hidden types
+
+Most property types are internal machinery (workflow states, configuration) and should stay `hidden: true`. Set `hidden: false` only for types that users actually browse in the platform UI — catalogs of locations, teams, or employees that show up in form pickers. When you do, you **must** list the roles allowed to browse them:
+
+```yaml
+hidden: false
+viewPermissions:
+  - Admin
+  - "Human Resources"   # spaces are allowed in role names
+```
+
+<div className="alert alert--info">
+
+**You can't delete a schema node via YAML.** If the server has fields your YAML doesn't, `cotctl` keeps them — omission is never destructive here. To retire a node, set `isActive: false` on it.
+
+</div>
+
+## Properties
+
+A property is an instance. It names its type and fills in the schema with a `schemaInstance`:
+
+```yaml
+kind: Property
+code: santiago
+display: Santiago
+propertyType: location          # immutable after creation
+schemaInstance:
+  address: Av. Providencia 1234
+  city: Santiago
+  country: Chile
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `kind` | Yes | Always `Property` |
+| `code` | Yes | Unique per company. Min 3 chars. **Immutable** |
+| `display` | Yes | UI display name (mutable) |
+| `propertyType` | Yes | The type's **code**. **Immutable after creation** |
+| `schemaInstance` | No | The data, keyed by the type's `schemaNodes[].key` |
+
+The keys inside `schemaInstance` must match the `key` fields you defined on the property type. To check which keys are valid:
+
+```bash
+cotctl property-types get location -c acme
+```
+
+### Hierarchies with `subproperty`
+
+Properties can form parent-child trees via `subproperty` (a list of child property codes) — useful for things like regions containing cities:
+
+```yaml
+kind: Property
+code: region_sur
+display: Región Sur
+propertyType: location
+subproperty:
+  - santiago
+  - temuco
+```
+
+Children must exist before the parent — or be applied in the same batch file.
+
+<div className="alert alert--primary">
+
+**Two immutable fields on a property: `code` and `propertyType`.** Neither can change after creation. To "move" a property to a different type, deactivate the old one and create a new property with the right type — the data doesn't migrate automatically.
+
+</div>
+
+## Deactivating
+
+Prefer the dedicated command:
+
+```bash
+cotctl properties deactivate santiago -c acme
+```
+
+If a property is still referenced by an active workflow or form, deactivation is **blocked** — resolve the dependency first. Note that deactivating a property *type* does not deactivate its properties; they remain active but orphaned, so deactivate in the right order.
+
+## See also
+
+- [apply](../commands/apply.md) — apply order puts types before properties
+- [Workflows](./workflows.md) — workflow states are properties
+- [Job titles](./jobtitles.md) — reference property types and properties

--- a/docs/developer/cli/resources/roles.md
+++ b/docs/developer/cli/resources/roles.md
@@ -1,0 +1,98 @@
+---
+title: Access roles (YAML)
+sidebar_label: Roles
+displayed_sidebar: developer
+---
+
+An **access role** bundles a set of permissions under a name. Roles are the foundation of access control in Cotalker — every other resource that grants access (workflows, property types, job titles, users) refers to roles by name. That's why `cotctl apply --dir` applies roles *first*: everything else depends on them.
+
+## The shape of a role
+
+A role is a `name`, an optional `description`, and a list of `permissions`:
+
+```yaml
+kind: AccessRole
+name: "ordenes-compra:manager"
+description: "Manager role — full access to the OC flow"
+active: true
+permissions:
+  - ordenes-compra:start-form
+  - ordenes-compra:view
+  - ordenes-compra:view-all
+  - ordenes-compra:write
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `kind` | Yes | Always `AccessRole` |
+| `name` | Yes | Unique per company. **Case-sensitive** — it's the upsert key |
+| `description` | No | Free text |
+| `active` | No | Defaults to `true`. **Note the field is `active`, not `isActive`** |
+| `permissions` | Yes | At least one permission |
+
+<div className="alert alert--secondary">
+
+**Two easy mistakes to avoid.** First, the active flag here is `active` — not `isActive` like every other resource. Writing `isActive` is silently ignored. Second, `name` is case-sensitive: `Admin` and `admin` are *different* roles, so applying the wrong casing creates a brand-new role instead of updating the one you meant.
+
+</div>
+
+## Naming conventions
+
+Cotalker's implementation convention is one role per permission, named `{flow}:{action}`, plus an aggregate "Manager" role that holds the full set:
+
+```yaml
+# Composable, one permission each
+name: "ordenes-compra:start-form"
+name: "ordenes-compra:view"
+name: "ordenes-compra:view-all"
+name: "ordenes-compra:write"
+
+# Aggregate
+name: "Órdenes de Compra: Manager"
+```
+
+This composability is what lets you assign exactly the right access to each job title. `cotctl` prints non-blocking warnings for names that stray from the `{flow}:{action}` convention.
+
+## Renaming a role
+
+Changing `name` creates a *new* role — it doesn't rename the existing one. To rename in place while keeping all references intact, pin the role by its `id`:
+
+```bash
+cotctl roles export "Old Name" -c acme -o role.yaml
+```
+
+Then uncomment the `id` line in the exported file, change `name`, and apply. (The role's permissions can be edited at the same time.)
+
+## Deactivating
+
+Either the dedicated command:
+
+```bash
+cotctl roles deactivate "old-role:viewer" -c acme
+```
+
+…or declaratively with `active: false` in the YAML, which is handy in version-controlled, batch setups.
+
+## Applying several at once
+
+A single file can hold many roles, separated by `---` — this is the common pattern for a workflow's whole permission set:
+
+```yaml
+kind: AccessRole
+name: "ordenes-compra:manager"
+permissions:
+  - ordenes-compra:view
+  - ordenes-compra:write
+---
+kind: AccessRole
+name: "ordenes-compra:solicitante"
+permissions:
+  - ordenes-compra:start-form
+  - ordenes-compra:view
+```
+
+## See also
+
+- [apply](../commands/apply.md) — roles are applied first
+- [Job titles](./jobtitles.md) and [Workflows](./workflows.md) — both reference roles by name
+- Use `cotctl roles list -c <profile>` to see existing role names and their exact casing

--- a/docs/developer/cli/resources/surveys.md
+++ b/docs/developer/cli/resources/surveys.md
@@ -1,0 +1,121 @@
+---
+title: Surveys (YAML)
+sidebar_label: Surveys
+displayed_sidebar: developer
+---
+
+A **survey** is a form — the way Cotalker captures structured data from people. Surveys are usually the first resource partners learn to manage with `cotctl`, because they're self-contained and immediately useful. This page explains the YAML structure so you can author and version them confidently.
+
+## The shape of a survey
+
+At its simplest, a survey is a `code`, a `name`, and a list of `questions`:
+
+```yaml
+kind: Survey
+code: registro_empleado
+name: "Employee Registration"
+questions:
+  - type: textinput
+    identifier: re_nombre
+    label: "Name"
+```
+
+### Root fields
+
+| Field | Required | Description |
+|---|---|---|
+| `kind` | Yes | Always `Survey` |
+| `code` | Yes | Unique per company. Lowercase letters, numbers, underscores. **Immutable after creation** |
+| `name` | Yes | Display name |
+| `isActive` | No | Defaults to `true` |
+
+<div className="alert alert--primary">
+
+**`code` is immutable.** Once a survey is created, its `code` can't change — choose it carefully. The same is true of each question's `identifier`. To "rename" either, you create a new resource. This is why we recommend a clear naming convention from the start.
+
+</div>
+
+Beyond these, surveys support many optional fields for who can respond, post-submission editing, conditional visibility, scoring, and binding answers to task fields. You'll reach for those as projects demand; this page focuses on the structure you'll use every day.
+
+## Questions
+
+`questions` is an array, and every question shares a common set of fields regardless of its type:
+
+| Field | Required | Description |
+|---|---|---|
+| `type` | Yes | The question type (see below) |
+| `identifier` | Yes | Company-wide unique ID |
+| `label` | Yes | The visible label |
+| `help` | No | Secondary help text |
+| `required` | No | Defaults to `false` |
+| `isReadOnly` | No | Defaults to `false` |
+
+### Identifiers: the one rule to internalize
+
+A question's `identifier` must be **unique across the entire company**, not just within this survey. The convention that keeps you out of trouble is to **prefix every identifier with the survey code**:
+
+```yaml
+# GOOD — prefixed, won't collide
+identifier: re_nombre
+
+# BAD — generic, will collide with other surveys
+identifier: nombre
+```
+
+A few words are reserved and can't be used as identifiers: `survey`, `user`, `channel`, `_id`, `UUID`, `target`, `properties`.
+
+### Question types
+
+Cotalker offers a rich set of question types. Here's the catalog — pick the one that matches the data you're capturing:
+
+| Type | For |
+|---|---|
+| `text` | Static text, titles, separators |
+| `textinput` | Free text |
+| `textnumber` | Numbers, integers, ratings |
+| `listquestion` | Single/multiple choice (radio/checkbox) |
+| `property` | Selecting from a data-model property |
+| `person` | Selecting a person |
+| `api` | Selecting from an external API |
+| `datetime` | Date and time |
+| `gps` | A location |
+| `image` | A photo or image |
+| `file` | A file attachment |
+| `signature` | A digital signature |
+| `survey` | An embedded sub-survey |
+
+A couple of types have required sub-fields worth remembering: `listquestion` needs a non-empty `options` list, and `property` needs a `filters` block:
+
+```yaml
+- type: listquestion
+  identifier: re_cargo
+  label: "Role"
+  options:
+    - label: "Analyst"
+      value: "analista"
+
+- type: property
+  identifier: re_area
+  label: "Area"
+  filters:
+    - propertyType: "area"
+      subfilter: "*"
+```
+
+## Editing surveys safely
+
+Because [`apply`](../commands/apply.md) matches questions by `identifier` rather than position, you can add, edit, remove, and reorder questions freely — IDs are preserved. Removing a question deactivates it (it isn't hard-deleted), and you'll be asked to confirm. If you apply a survey YAML without its `questions` section, the existing questions are left untouched.
+
+## A practical tip
+
+The fastest way to learn the full structure is to export a real survey and read it:
+
+```bash
+cotctl surveys export <some_survey> -c acme -o example.yaml
+```
+
+## See also
+
+- [apply](../commands/apply.md) — how surveys are created and updated
+- [Export & import](../commands/export-import.md) — the export options, including `--extract-scripts`
+- [Workflows](./workflows.md) — surveys are referenced by workflow transitions

--- a/docs/developer/cli/resources/users.md
+++ b/docs/developer/cli/resources/users.md
@@ -1,0 +1,101 @@
+---
+title: Users (YAML)
+sidebar_label: Users
+displayed_sidebar: developer
+---
+
+A **user** is a person in a company. Users are the most connected resource in Cotalker — each one references a [job title](./jobtitles.md), one or more [access roles](./roles.md), and can sit in an org-chart hierarchy with other users. Because of those dependencies, users are applied **last** (after job titles and roles exist).
+
+## The shape of a user
+
+```yaml
+kind: User
+email: juan.perez@acme.com
+name:
+  names: Juan
+  lastName: Pérez
+job: store_manager               # JobTitle code — must be active
+accessRoles:
+  - "ordenes-compra:manager"     # AccessRole names — case-sensitive
+phone: "+56912345678"
+isActive: true
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `kind` | Yes | Always `User` |
+| `email` | Yes | The upsert key. Globally unique, auto-lowercased. **Immutable after creation** |
+| `name` | Yes | Sub-object: `names` (required), `lastName`, `secondLastName` |
+| `job` | Yes | A JobTitle **code** that exists and is **active** |
+| `accessRoles` | No | AccessRole **names** (case-sensitive) |
+| `phone`, `isActive`, `settings` | No | Optional profile fields |
+
+The `name` field is an object, not a string. `cotctl` builds the display name from it automatically:
+
+```yaml
+name:
+  names: Juan
+  lastName: Pérez
+  secondLastName: García
+```
+
+## Job and roles
+
+`job` points to a job title by **code**, and that job title must be active — `cotctl` only resolves active ones. `accessRoles` lists role **names**, and like everywhere else, they're case-sensitive (`Manager` ≠ `manager`).
+
+<div className="alert alert--info">
+
+**The default role.** If you create a user with no `accessRoles`, the backend assigns a `default` role automatically. You'll see it appear in later exports — that's expected, not a bug.
+
+</div>
+
+## Hierarchy
+
+You can place a user in the org chart with `hierarchy`. All three lists contain **emails**, resolved at apply time:
+
+```yaml
+hierarchy:
+  boss:
+    - manager@acme.com
+  peers:
+    - colleague@acme.com
+  subordinate:          # ← singular!
+    - junior1@acme.com
+    - junior2@acme.com
+```
+
+<div className="alert alert--primary">
+
+**`subordinate` is singular.** The key is `subordinate`, not `subordinates`. Because the user schema is lenient, writing the plural produces *no error* — the user is applied with no subordinates set, silently. Double-check this key whenever you build a hierarchy.
+
+</div>
+
+When you apply a batch of users that reference each other (A's boss is B, both new), `cotctl` handles it with a two-pass apply, so forward references resolve correctly.
+
+## Custom metadata: `extra`
+
+`extra` is a free key-value map for anything else you need to store:
+
+```yaml
+extra:
+  department: "Sales"
+  rut: "12.345.678-9"
+```
+
+On update, `extra` is **merged** — keys you provide win, keys already on the server are kept. You can't delete an `extra` key through YAML.
+
+<div className="alert alert--secondary">
+
+**`extra` often holds PII** (national IDs, etc.), and it appears as-is in exports. Review this field before committing an exported user YAML to version control.
+
+</div>
+
+## A note on passwords
+
+`password` is write-only — you can set it on apply, but it's never exported. For onboarding flows and the details of how passwords and reactivation behave, see the command reference.
+
+## See also
+
+- [Job titles](./jobtitles.md) — the `job` a user references (apply these first)
+- [Roles](./roles.md) — the `accessRoles` a user references
+- [apply](../commands/apply.md) — users are applied last

--- a/docs/developer/cli/resources/workflows.md
+++ b/docs/developer/cli/resources/workflows.md
@@ -1,0 +1,138 @@
+---
+title: Workflows (YAML)
+sidebar_label: Workflows
+displayed_sidebar: developer
+---
+
+A **workflow** models a process: a task that moves through a series of states, from creation to closure. Workflows are the most powerful — and the most structured — resource in Cotalker. The good news is you rarely write one from scratch: [`cotctl workflows scaffold`](../commands/scaffolding.md) generates a correct skeleton, and this page explains what that skeleton contains so you can customize it with confidence.
+
+## The hierarchy
+
+A single workflow YAML document manages a nested structure:
+
+```
+Workflow                 (the process: name, permissions, settings)
+└── stateMachines[]      (one or more independent flows)
+    └── states[]         (the steps a task moves through)
+        └── next[]       (the allowed transitions between states)
+```
+
+## The workflow level
+
+The top of the file describes the workflow itself:
+
+```yaml
+kind: Workflow
+nameCode: purchase_orders        # immutable after creation
+nameDisplay: Purchase Orders
+isActive: true
+hideClosedAfterDays: 30
+readPermissions:
+  - Admin                        # AccessRole names
+writePermissions:
+  - Admin
+  - Manager
+stateMachines:
+  - # ...
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `kind` | Yes | Always `Workflow` |
+| `nameCode` | Yes | Unique per company. **Immutable after creation.** Min 3 chars, lowercase/underscores |
+| `nameDisplay` | No | Display name. If omitted, apply runs in "SM-only mode" (see below) |
+| `isActive` | No | Defaults to `true` |
+| `hideClosedAfterDays` | No | Days before closed tasks are hidden. **Defaults to 7, which is often too short** — consider 30 |
+| `readPermissions` / `writePermissions` | No | AccessRole **names** — who can read / create tasks |
+
+<div className="alert alert--secondary">
+
+**Permissions are matched by name, and typos fail silently.** Permission lists use AccessRole *names*, which `cotctl` resolves to IDs on apply. If a name doesn't exist on the server, it is **silently dropped** — no error. After applying, verify with `cotctl workflows get <nameCode>` that every permission landed.
+
+</div>
+
+## State machines
+
+Each entry in `stateMachines[]` is an independent flow. It declares which data drives it and where it starts:
+
+```yaml
+stateMachines:
+  - code: sm_po_main
+    name: PO Main Flow
+    propertyType: pt_po_states     # immutable after creation
+    asset:
+      type: unique                 # "unique" or "generic" — immutable
+      propertyType: pt_po_assets
+    initialState: po_draft         # a state property code
+    states:
+      - # ...
+```
+
+The `propertyType` and `asset.type` are **immutable after creation** — they define the fundamental shape of the flow, so plan them up front.
+
+## States and transitions
+
+Each state corresponds to a [Property](./properties.md) and declares its lifecycle type and its outgoing transitions:
+
+```yaml
+states:
+  - property: po_draft        # a Property code that must already exist
+    type: new                 # "new" | "in-progress" | "closed" — immutable
+    next:
+      - target: po_approved
+        canChange: manual
+      - target: po_rejected
+        canChange: survey
+        requiredSurvey: survey_rejection_reason
+```
+
+A transition's `canChange` controls how it fires:
+
+| `canChange` | Meaning |
+|---|---|
+| `manual` (default) | A user triggers it from the task UI |
+| `survey` | The user must complete a survey first — set `requiredSurvey` to its code |
+| `none` | Only automation/system can trigger it (e.g. auto-closure) |
+
+<div className="alert alert--primary">
+
+**States are permanent.** Once created, a state can't be deleted or deactivated, and its `type` can't change. Removing a state from your YAML doesn't delete it — apply will block the change. Design your state set deliberately.
+
+</div>
+
+## Automation: bots
+
+Transitions and states can trigger **bots** — small automation routines that run when a transition fires or a form is submitted (sending a notification, creating a follow-up task, calling an API). Bots are an advanced topic with their own catalog of types; for now, what matters is one safety rule:
+
+<div className="alert alert--secondary">
+
+**The three forms of a `bots` field — and why it matters.** When you write a `bots` slot in YAML, the form you choose changes behavior:
+
+| YAML | Effect on apply |
+|---|---|
+| Field **absent** | **Preserve** whatever bots the server already has in that slot |
+| `bots: []` | **Delete** the bots in that slot (destructive) |
+| `bots: [{...}]` | **Replace** with the bot you declared |
+
+If bots were configured outside `cotctl` (for example, in the web builder), an accidental `bots: []` will wipe them. When in doubt, `cotctl workflows export` first to see what's there.
+
+</div>
+
+## SM-only mode
+
+If you omit `nameDisplay`, apply runs in **SM-only mode**: it touches only the state machines and states, leaving the workflow's display settings and permissions untouched. This is exactly what you want when adding a second state machine to a workflow that already exists, without resetting anything.
+
+## A dependency note
+
+A transition's `requiredSurvey` references a survey by code. Because of apply ordering, when you use `apply --dir`, workflows are applied *before* surveys. If a transition needs a survey, apply the surveys first, then the workflow:
+
+```bash
+cotctl surveys apply -f surveys.yaml -c acme
+cotctl workflows apply -f workflow.yaml -c acme
+```
+
+## See also
+
+- [Scaffolding](../commands/scaffolding.md) — generate the workflow skeleton
+- [Properties](./properties.md) and [Roles](./roles.md) — the resources a workflow references
+- [validate](../commands/validate.md) — the production-readiness checklist for live workflows

--- a/docs/developer/cli/skills.md
+++ b/docs/developer/cli/skills.md
@@ -1,0 +1,88 @@
+---
+title: Skills for Claude Code
+sidebar_label: Skills
+displayed_sidebar: developer
+---
+
+A **Skill** is an installable package that gives the Claude Code AI agent specialized knowledge and tools for a specific area. `cotctl` ships a set of Skills — one per resource type — that turn a general-purpose agent into a Cotalker authoring specialist. This page is the reference for the `cotctl skills` command that manages them. For the bigger picture of how Skills fit with the RAG and the agent, see [AI-assisted authoring](./ai-authoring.md).
+
+## Listing what's available
+
+```bash
+cotctl skills list
+```
+
+This shows every available Skill and its installation status, which can be `[not installed]`, `[local]`, `[global]`, or `[local, global]`.
+
+## Installing Skills
+
+```bash
+cotctl skills install [name] [options]
+```
+
+Run it **without a name** to get an interactive checklist and pick what you want. Provide a name to install a specific one.
+
+| Option | Description |
+|---|---|
+| `--all` | Install every available Skill |
+| `--local` | Install to `.claude/skills/` (this project only) |
+| `--global` | Install to `~/.claude/skills/` (all projects) |
+| `--no-mcp` | Skip the Cotalker RAG/MCP configuration step |
+
+If you don't pass `--local` or `--global`, `cotctl` asks you interactively which scope to use.
+
+<div className="alert alert--info">
+
+**Installing also offers to connect the RAG.** After installing, `cotctl` offers to configure the MCP connection to Cotalker's documentation service — the "live grounding" half of the setup. Skip it with `--no-mcp`, or set it up later with [`cotctl mcp install`](./mcp-integration.md). For most partners, accepting it is the right call.
+
+</div>
+
+## The available Skills
+
+Each Skill specializes the agent in one resource area:
+
+| Skill | What it gives the agent |
+|---|---|
+| `cotctl-surveys` | Creating and modifying survey YAML |
+| `cotctl-workflows` | Creating, scaffolding, and modifying workflows |
+| `cotctl-properties` | Generating property types and properties |
+| `cotctl-roles` | Creating and managing access roles and permissions |
+| `cotctl-apply` | Applying resources to Cotalker environments |
+| `cotctl-export` | Exporting and querying resources |
+| `cotalker-docs` | General knowledge of the Cotalker platform |
+
+A common starting point is to install them all:
+
+```bash
+cotctl skills install --all --local
+```
+
+## Scopes: local vs. global
+
+Where a Skill is installed determines which projects can use it:
+
+| Scope | Directory | Applies to |
+|---|---|---|
+| Local | `.claude/skills/` | The current project only |
+| Global | `~/.claude/skills/` | All your projects |
+
+Use **local** when you're working on a specific client's repository and want the Skills versioned alongside it; use **global** when you want them available everywhere you work.
+
+## Uninstalling
+
+```bash
+cotctl skills uninstall [name] [options]
+```
+
+| Option | Description |
+|---|---|
+| `--all` | Uninstall every Skill from the selected scope |
+| `--local` | Uninstall from the current project |
+| `--global` | Uninstall from the global configuration |
+
+When you uninstall with `--all`, `cotctl` also asks whether to remove the RAG/MCP configuration that was set up alongside the Skills.
+
+## See also
+
+- [AI-assisted authoring](./ai-authoring.md) — how Skills, the RAG, and the agent work together
+- [MCP integration](./mcp-integration.md) — the documentation RAG the Skills offer to connect

--- a/docs/developer/cli/troubleshooting.md
+++ b/docs/developer/cli/troubleshooting.md
@@ -1,0 +1,83 @@
+---
+title: Troubleshooting
+sidebar_label: Troubleshooting
+displayed_sidebar: developer
+---
+
+Most `cotctl` errors are clear and tell you how to fix them. This page collects the ones you're most likely to hit, organized as **symptom → cause → fix** so you can scan for yours quickly.
+
+## Installation & setup
+
+### `cotctl: command not found` after a global install
+
+- **Cause:** the npm global bin directory isn't on your `PATH`.
+- **Fix:** confirm where npm installs global binaries with `npm bin -g`, and add that directory to your `PATH`. As a quick workaround, you can always run the tool via `npx @cotctl/cli <command>`.
+
+## Authentication & profiles
+
+### `--company/-c is required`
+
+- **Cause:** the command needs a profile and you didn't pass one. There's no default, by design.
+- **Fix:** add `-c <profile>`. Run `cotctl profile list` to see the available names.
+
+### `Profile '<name>' not found`
+
+- **Cause:** that profile doesn't exist locally (typo, or you never logged in to it).
+- **Fix:** check `cotctl profile list`; run `cotctl login` if it's missing.
+
+### `Session expired for profile "<name>"` / `Failed to refresh token`
+
+- **Cause:** the token is more than 7 days old, or it was revoked server-side.
+- **Fix:** run `cotctl login` again for that environment.
+
+### `API Error 401`
+
+- **Cause:** the token is invalid.
+- **Fix:** re-authenticate with `cotctl login`.
+
+### `API Error 403`
+
+- **Cause:** the logged-in user lacks the required administration permissions.
+- **Fix:** this is a Cotalker permissions matter — ask the company's administrator to grant the user the needed permissions, then retry.
+
+### `Could not discover API URL from <url>`
+
+- **Cause:** the webclient URL is wrong, or (common on-premise) the webclient doesn't serve the variables file `cotctl` reads to find the API.
+- **Fix:** double-check the `--url`. On-premise, pass the API explicitly with `--api-url https://api.empresa.com`.
+
+### `Token does not belong to the specified company`
+
+- **Cause:** the token was issued for a different company than the subdomain/URL you specified.
+- **Fix:** verify the `--subdomain` and `--url` match the environment you intend.
+
+## YAML & validation
+
+### `YAML parse error`
+
+- **Cause:** invalid YAML syntax — usually indentation or a stray character.
+- **Fix:** check indentation (spaces, not tabs) and formatting. Running `cotctl validate -f <file>` points at the problem line.
+
+### Identifier conflict on remote validation / `Duplicate key error`
+
+- **Cause:** a question `identifier` already exists in another survey in the company — identifiers are unique company-wide, not per survey.
+- **Fix:** rename the identifier, prefixing it with the survey code (e.g. `re_nombre` instead of `nombre`).
+
+### An exec hook doesn't run, or `Illegal return statement`
+
+- **Cause:** the script's `src` is missing its `function run()` wrapper, so a top-level `return` is invalid.
+- **Fix:** wrap the logic in `function run() { ... }` (or `async function run()`).
+
+## Surveys: orphaned questions
+
+This one is worth understanding because it's easy to avoid and annoying to undo.
+
+- **Symptom:** after applying a survey with `questions: []`, you can no longer re-create questions with the same identifiers.
+- **Cause:** applying an *empty* questions array leaves the old questions behind as orphaned records, and their identifiers (unique per company) now block re-creation.
+- **Fix / prevention:** never apply `questions: []` to "clear" a survey. To deactivate a survey, set `isActive: false` *without* touching the questions section — `cotctl` preserves existing questions automatically when the section is absent. (Recovering from an existing orphan requires backend cleanup, so prevention is the play here.)
+
+## Still stuck?
+
+- Re-run the command — many errors include a precise hint about the fix.
+- For schema questions, export a working example of the same resource and compare:
+  `cotctl <entity> export <code> -c <profile> -o example.yaml`
+- See the [command reference](./commands/apply.md) for the exact options and behavior of each command.

--- a/docs/developer/cli/tutorials.md
+++ b/docs/developer/cli/tutorials.md
@@ -1,0 +1,119 @@
+---
+title: Tutorials
+sidebar_label: Tutorials
+displayed_sidebar: developer
+---
+
+The reference pages tell you *what* each command does. This page shows you *how* they fit together, with complete, follow-along recipes for the things you'll actually do on a project. Each recipe lists what you need before you start and what success looks like, so you can tell when it worked.
+
+If you haven't installed and authenticated yet, start with [Installation](./installation.md) and [Authentication](./authentication.md) — every recipe below assumes you have a working profile.
+
+## Recipe 1 — Log in and confirm your setup
+
+**What you'll need:** `cotctl` installed, and admin access to an environment.
+
+```bash
+# Log in (browser flow by default)
+cotctl login --url https://web.cotalker.com --subdomain acme
+
+# Confirm the profile was saved
+cotctl profile list
+```
+
+**What success looks like:** `cotctl profile list` shows an `acme` row with your URL and user. You're ready to run any command with `-c acme`.
+
+## Recipe 2 — Create a new survey from scratch
+
+**What you'll need:** a working profile, and an idea of the form you want to build.
+
+```bash
+# 1. Write the YAML (see the Surveys reference for structure)
+vim my-survey.yaml
+
+# 2. Validate it offline — catch mistakes before touching the environment
+cotctl validate -f my-survey.yaml
+
+# 3. Preview what would be sent, changing nothing
+cotctl apply -f my-survey.yaml -c acme --dry-run
+
+# 4. Apply for real
+cotctl apply -f my-survey.yaml -c acme
+```
+
+**What success looks like:**
+
+```
+Survey "my_survey" created successfully (id: 507f1f77bcf86cd799439011)
+```
+
+<div className="alert alert--info">
+
+This validate → dry-run → apply sequence is the safe default for *every* resource, not just surveys. Build the habit now.
+
+</div>
+
+## Recipe 3 — Modify an existing survey
+
+**What you'll need:** the `code` of a survey that already exists.
+
+```bash
+# 1. Export it as your starting point
+cotctl surveys export existing_survey -c acme -o survey.yaml
+
+# 2. Edit the YAML
+vim survey.yaml
+
+# 3. Validate, then apply — it updates automatically because the code exists
+cotctl validate -f survey.yaml
+cotctl apply -f survey.yaml -c acme
+```
+
+**What success looks like:** `Survey "existing_survey" updated successfully`. You can add, remove, edit, and reorder questions freely — `cotctl` matches them by `identifier` and preserves their IDs.
+
+## Recipe 4 — Promote a survey between environments
+
+**What you'll need:** profiles for both the source and the target environment.
+
+```bash
+# 1. Export from the source
+cotctl surveys export my_survey -c acme-prod -o survey.yaml
+
+# 2. Apply to the target
+cotctl apply -f survey.yaml -c devteam
+```
+
+**What success looks like:** the survey is created in the target environment. The exported YAML contains IDs from the source, but those are ignored on creation — the target generates its own.
+
+## Recipe 5 — Build and deploy a workflow from a scaffold
+
+This is the big one — the full loop from nothing to a live workflow.
+
+**What you'll need:** a working profile and a name + short code for your flow.
+
+```bash
+# 1. Generate the skeleton
+cotctl workflows scaffold --name ordenes-compra --code oc \
+  --display "Órdenes de Compra"
+
+# 2. Customize the generated files:
+#    - states in data-model/states.yaml
+#    - transitions in workflow.yaml
+#    - roles/permissions in access/
+
+# 3. Validate the whole folder offline
+cotctl validate --dir ordenes-compra/
+
+# 4. Apply — entities deploy in the right dependency order automatically
+cotctl apply --dir ordenes-compra/ -c dev
+
+# 5. Run the production-readiness checklist against the live workflow
+cotctl validate --workflow ordenes_compra -c dev
+```
+
+**What success looks like:** step 4 reports `N created, 0 errors`, and step 5 ends with `production ready`. Steps 2–5 form a loop you can repeat safely — every apply is idempotent.
+
+## Where to go next
+
+- [Resource YAML reference](./resources/surveys.md) — the schema behind each file you edit
+- [Troubleshooting](./troubleshooting.md) — when a recipe doesn't go to plan
+- [CI/CD](./ci-cd.md) — run these flows automatically on every merge

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/ai-authoring.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/ai-authoring.md
@@ -1,0 +1,92 @@
+---
+title: Authoring asistido por IA (Skills y RAG)
+sidebar_label: Authoring con IA
+displayed_sidebar: developer
+---
+
+Hasta acá esta guía trató a `cotctl` como una herramienta que *vos* manejás a mano. Pero `cotctl` es también la base de algo más grande: **crear configuraciones de Cotalker con la ayuda de un agente de IA.** Esta página explica cómo encaja ese ecosistema — y por qué te vuelve, como partner, dramáticamente más rápido.
+
+## La idea en una imagen
+
+Escribir el YAML de recursos a mano es preciso pero lento, y es fácil olvidar un campo o una convención de nombres. Un agente de IA como **Claude Code** puede escribir ese YAML por vos — *si* sabe dos cosas: cómo están estructurados los recursos de Cotalker, y qué existe realmente en la plataforma ahora mismo. `cotctl` provee exactamente esas dos cosas, a través de **Skills** y **RAG**:
+
+```
+              Claude Code  (el agente de IA)
+                    │   escribe el YAML por vos
+        ┌───────────┴────────────┐
+        │                        │
+     SKILLS                   RAG (vía MCP)
+ cotctl skills install     cotctl mcp install
+ → experticia de dominio:  → grounding en vivo:
+   cómo se crea cada          documentación
+   recurso                    actualizada de Cotalker
+        └───────────┬────────────┘
+                    ▼
+   YAML correcto → cotctl validate → cotctl apply
+```
+
+- **Skills** le enseñan al agente *cómo* escribir cada tipo de recurso (una encuesta, un workflow, un rol…), codificando las convenciones de Cotalker para que la salida esté bien formada.
+- **RAG** (a través de un servidor MCP) groundea al agente en la documentación *actual* de Cotalker, así responde desde material de referencia real en vez de adivinar nombres de campos.
+
+Juntos, vos describís lo que querés en lenguaje natural, el agente produce YAML groundeado, y terminás con el mismo ciclo confiable `validate` → `apply` que ya conocés.
+
+## Las tres piezas
+
+### 1. El agente
+
+[Claude Code](https://claude.com/claude-code) es el asistente de IA que hace el authoring. Por sí solo es un generalista capaz; las dos piezas siguientes lo convierten en un especialista en Cotalker.
+
+### 2. Skills — experticia de dominio, instalada
+
+Un **Skill** es un paquete instalable que le da al agente conocimiento y herramientas especializadas para un área. `cotctl` trae un conjunto de ellos — uno por tipo de recurso — que instalás con un solo comando:
+
+```bash
+cotctl skills install
+```
+
+Una vez instalados, pedirle al agente "creá un workflow de órdenes de compra" produce YAML que sigue la estructura y las convenciones de nombres de Cotalker, porque el Skill correspondiente lo está guiando. La referencia completa del comando — listar, scopes, y los Skills disponibles — está en la página de [Skills](./skills.md).
+
+### 3. RAG — grounding en documentación viva
+
+**RAG** (Retrieval-Augmented Generation) le permite al agente consultar la documentación de Cotalker mientras trabaja, vía un servidor **MCP**. Esto es lo que evita que invente un campo que no existe: cuando duda, recupera la referencia real. Lo conectás con:
+
+```bash
+cotctl mcp install
+```
+
+Convenientemente, instalar los Skills ya ofrece configurar esto por vos. Los detalles completos — índices, scopes, múltiples servidores — están en la página de [Integración MCP](./mcp-integration.md).
+
+## El ciclo de authoring, de punta a punta
+
+Así se ve trabajar de esta forma:
+
+```bash
+# 1. Setup único: instalar los Skills (esto también ofrece conectar el RAG/MCP)
+cotctl skills install --all
+
+# 2. En Claude Code, describí lo que querés en lenguaje natural, ej.:
+#    "Scaffoldeá un workflow de órdenes de compra con estados borrador,
+#     pendiente, aprobado y rechazado, y un rol manager con acceso total."
+#    → el agente escribe el YAML, groundeado por los Skills + RAG.
+
+# 3. Mantenés el control con el ciclo de seguridad de siempre:
+cotctl validate --dir ordenes-compra/
+cotctl apply    --dir ordenes-compra/ -c dev
+cotctl validate --workflow ordenes_compra -c dev
+```
+
+<div className="alert alert--primary">
+
+**Siempre sos el revisor.** El agente draftea; vos validás y aplicás. Nada llega a un entorno sin pasar por `cotctl validate` y tu `apply` explícito. La IA hace el authoring más rápido — no quita las barreras de seguridad.
+
+</div>
+
+## Por qué esto importa para los partners
+
+Esta es la diferencia entre *configurar Cotalker* e *implementar sobre Cotalker con velocidad*. Los Skills cargan las convenciones para que no tengas que memorizarlas, el RAG mantiene todo actualizado a medida que la plataforma evoluciona, y `cotctl` sigue siendo la forma confiable de validar y publicar lo que el agente produce. El resultado es una entrega más rápida con la misma — o mejor — corrección.
+
+## Próximos pasos
+
+- [**Skills**](./skills.md) — instalá y gestioná los Skills de Cotalker para Claude Code
+- [**Integración MCP**](./mcp-integration.md) — conectá el RAG de documentación
+- [**Tutoriales**](./tutorials.md) — los flujos de recursos que el agente te ayuda a crear

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/authentication.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/authentication.md
@@ -112,14 +112,15 @@ acme          https://www.cotalker.com         acme         admin@acme.com
 devteam       https://staging.cotalker.com     devteam      dev@cotalker.com
 ```
 
-**Eliminar uno.** Cuando ya no necesitás un entorno, eliminá su perfil. Esto lo quita de tu archivo local — **no** invalida el token en el servidor:
+**Eliminar uno.** Cuando ya no necesitás un entorno, cerrá sesión en él. Para los perfiles modernos de tipo API-token esto **revoca el token en el servidor** y luego quita el perfil local:
 
 ```bash
 cotctl logout acme
+# Remote ApiToken revoked.
 # Logged out from profile "acme".
 ```
 
-`cotctl profile delete <name>` hace lo mismo, con una confirmación.
+Si solo querés olvidar un perfil localmente **sin** revocar su token, usá `cotctl profile delete <name>`.
 
 ## No tenés que preocuparte por la renovación del token
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/authentication.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/authentication.md
@@ -1,0 +1,140 @@
+---
+title: Autenticación
+sidebar_label: Autenticación
+displayed_sidebar: developer
+---
+
+Ahora que `cotctl` está instalado, necesita saber *con qué entorno de Cotalker hablar* y *quién sos vos*. Esta página explica cómo funciona la autenticación, te guía en tu primer login, e introduce los **perfiles** — el concepto que te permite manejar varios entornos con seguridad.
+
+## Cómo piensa cotctl la autenticación: perfiles
+
+`cotctl` guarda tus credenciales en un sistema de **perfiles**, en un archivo en `~/.cotctl/config.json`. Cada perfil contiene los datos de conexión y el token de un entorno o empresa.
+
+Esto importa porque, como partner, vas a trabajar seguido con más de una empresa — un entorno de staging, uno de producción, varios clientes. En vez de hacer login y logout constantemente, te logueás *una vez por entorno*, cada login se vuelve un perfil con nombre, y de ahí en más simplemente le decís a cada comando qué perfil usar.
+
+<div className="alert alert--primary">
+
+**Bueno saberlo.** No hay archivo `.env` ni token hardcodeado para andar copiando. Todo vive en el archivo de perfiles gestionado, que `cotctl` crea con permisos restrictivos. Nunca pegás un token a mano.
+
+</div>
+
+## Tu primer login
+
+Para conectarte a un entorno, usá `cotctl login`. El detalle más importante: el flag `--url` toma la **URL del webclient** — la dirección que abrirías en un navegador para usar Cotalker — *no* una URL de API. `cotctl` descubre la dirección de la API automáticamente a partir de eso.
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain acme
+```
+
+Por defecto esto abre tu navegador para iniciar sesión. Esto es lo que pasa, paso a paso:
+
+1. `cotctl` abre tu navegador en la página de autorización del entorno.
+2. Iniciás sesión (si no lo estabas) y aprobás el acceso.
+3. El token se transfiere de vuelta a la CLI automáticamente.
+4. Se guarda un perfil en `~/.cotctl/config.json` — llamado `acme` en este ejemplo, según el `--subdomain`.
+
+Si el navegador no se abre solo, `cotctl` imprime la URL en la terminal para que la abras manualmente.
+
+### Iniciar sesión sin navegador
+
+En un servidor, en CI, o cualquier entorno headless donde no haya navegador, agregá `--no-browser` para iniciar sesión con email y contraseña:
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain acme --no-browser
+```
+
+```
+Email: admin@acme.com
+Password: ********
+
+Logged in as admin@acme.com (company: 64a1b2c3...)
+Profile saved as "acme"
+Use with: cotctl surveys list -c acme
+```
+
+### Todas las opciones de login
+
+| Opción | Descripción |
+|---|---|
+| `--url <url>` | **(requerido)** URL del webclient del entorno |
+| `--subdomain <name>` | **(requerido)** Subdominio o nombre de empresa |
+| `--api-url <url>` | URL de la API, si necesitás sobrescribir el autodescubrimiento |
+| `--no-browser` | Usa email/contraseña en vez del flujo de navegador |
+| `--profile <name>` | Nombre de perfil personalizado (por defecto, el valor de `--subdomain`) |
+
+## El flag `-c`: decirle a los comandos sobre qué empresa actuar
+
+Este es el hábito más importante a construir. **Todo comando que toca la API requiere un flag `-c` (o `--company`)** que nombre el perfil a usar. A propósito no hay default — esto evita que ejecutes un comando contra el entorno equivocado de un cliente.
+
+```bash
+cotctl surveys list -c acme
+cotctl apply -f survey.yaml -c acme
+cotctl surveys export my_survey -c acme
+```
+
+Si lo olvidás, `cotctl` se detiene y te avisa:
+
+```
+Error: --company/-c is required. Use 'cotctl profile list' to see available profiles.
+```
+
+Ese error es una función, no una molestia: es la barrera que evita que un cambio de staging termine en producción.
+
+## Trabajar con múltiples entornos
+
+Como cada login es su propio perfil, soportar varios entornos es simplemente varios logins:
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain acme
+cotctl login --url https://web.staging.cotalker.com --subdomain devteam
+cotctl login --url https://www.cotalkercoopeuch.com --subdomain coopeuch
+```
+
+Después, cambiar de entorno es solo cambiar el valor de `-c`:
+
+```bash
+cotctl surveys list -c acme
+cotctl surveys list -c devteam
+cotctl apply -f survey.yaml -c coopeuch
+```
+
+## Gestionar tus perfiles
+
+**Ver lo que tenés.** Para listar todos los perfiles guardados:
+
+```bash
+cotctl profile list
+```
+
+```
+NAME          URL                              SUBDOMAIN    USER
+acme          https://www.cotalker.com         acme         admin@acme.com
+devteam       https://staging.cotalker.com     devteam      dev@cotalker.com
+```
+
+**Eliminar uno.** Cuando ya no necesitás un entorno, eliminá su perfil. Esto lo quita de tu archivo local — **no** invalida el token en el servidor:
+
+```bash
+cotctl logout acme
+# Logged out from profile "acme".
+```
+
+`cotctl profile delete <name>` hace lo mismo, con una confirmación.
+
+## No tenés que preocuparte por la renovación del token
+
+Los tokens expiran, pero `cotctl` se encarga de renovarlos antes de cada llamada a la API, así que en uso normal rara vez te logueás más de una vez por semana:
+
+- **Menos de 50 minutos de antigüedad:** se usa tal cual.
+- **Entre 50 minutos y 7 días:** se renueva silenciosamente en segundo plano.
+- **Más de 7 días:** la sesión expiró y se te pedirá iniciar sesión de nuevo.
+
+Si no se puede renovar, `cotctl` te dice exactamente qué ejecutar:
+
+```
+Error: Session expired for profile "acme". Run: cotctl login --url https://web.cotalker.com --subdomain acme
+```
+
+## Próximo paso
+
+Estás conectado. Ahora pongámoslo a trabajar — andá a [**Comandos**](./commands/apply.md) para aprender `apply`, el verbo que más vas a usar.

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/ci-cd.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/ci-cd.md
@@ -1,0 +1,97 @@
+---
+title: Pipelines de CI/CD
+sidebar_label: CI/CD
+displayed_sidebar: developer
+---
+
+Todo lo que `cotctl` hace en tu laptop, lo puede hacer desatendido en un pipeline. Correrlo en CI/CD es lo que convierte "un partner despliega cambios a mano" en "los cambios se validan y despliegan automáticamente en cada merge" — repetible, revisable, y sin depender de que alguien recuerde los pasos. Esta página muestra la forma recomendada y, sobre todo, cómo manejar las credenciales con seguridad.
+
+## La forma recomendada del pipeline
+
+Un buen pipeline de `cotctl` refleja el flujo manual: **validar en cada cambio, aplicar en el merge.**
+
+1. **En un pull request** — ejecutá `cotctl validate --dir` (offline, no requiere credenciales). Esto detecta errores de esquema y referencias cruzadas antes de la revisión.
+2. **En el merge a tu rama principal** — ejecutá `cotctl apply --dir -c <profile>` contra el entorno destino, opcionalmente precedido por un `--dry-run`.
+
+Como cada apply es idempotente, re-ejecutar el deploy siempre es seguro.
+
+## Manejar las credenciales con seguridad
+
+Esta es la parte a hacer bien. En un pipeline no hay navegador para iniciar sesión, así que te autenticás de forma no interactiva — pero **nunca ponés un token en tu repositorio**.
+
+<div className="alert alert--primary">
+
+**La regla: los secrets viven en tu proveedor de CI, nunca en el código.** Guardá las credenciales como secrets encriptados de CI (GitHub Actions secrets, variables de GitLab CI, etc.) y leelas desde variables de entorno en runtime. Nunca commitees un token, y nunca pegues uno en un YAML o script que esté versionado.
+
+</div>
+
+Hay dos formas de autenticarte en CI, según lo que soporte tu entorno:
+
+**Opción A — login con `--no-browser` usando credenciales secretas.** El enfoque más limpio cuando tenés una cuenta de servicio con email/contraseña:
+
+```bash
+cotctl login \
+  --url https://web.cotalker.com \
+  --subdomain acme \
+  --no-browser
+# credenciales provistas vía las variables de entorno respaldadas por secrets de CI
+```
+
+**Opción B — proveer un token vía un secret.** Si generás un token por fuera, exponelo al job como una variable de entorno respaldada por un secret (por ejemplo `$COTCTL_TOKEN`) en vez de hardcodearlo. Referenciá la variable; nunca el valor literal.
+
+## Un ejemplo trabajado (GitHub Actions)
+
+Este workflow valida en los pull requests y despliega en los pushes a `main`. Las credenciales vienen enteramente de secrets del repositorio:
+
+```yaml
+name: Deploy Cotalker config
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm install -g @cotctl/cli
+      # Offline — no requiere credenciales
+      - run: cotctl validate --dir config/
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: validate
+    runs-on: ubuntu-latest
+    env:
+      COTCTL_EMAIL: ${{ secrets.COTCTL_EMAIL }}
+      COTCTL_PASSWORD: ${{ secrets.COTCTL_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm install -g @cotctl/cli
+      - run: cotctl login --url https://web.cotalker.com --subdomain acme --no-browser
+      - run: cotctl apply --dir config/ -c acme -y
+```
+
+Notá `cotctl apply ... -y` — el flag `-y` salta las confirmaciones interactivas, que es justo lo que querés en un job desatendido.
+
+## Vida útil del token en CI
+
+Los tokens expiran tras 7 días de inactividad. Para pipelines que corren regularmente esto rara vez es un problema, pero para deploys poco frecuentes, preferí una **cuenta de servicio** y reautenticarte al inicio de cada corrida en vez de cachear un token entre corridas.
+
+## Usá `--continue-on-error` deliberadamente
+
+Por defecto, un apply de directorio se detiene en la primera falla — normalmente lo que querés, así un deploy roto se detiene ruidosamente. Agregá `--continue-on-error` solo cuando intencionalmente quieras que las entidades restantes se apliquen a pesar de que una falle.
+
+## Ver también
+
+- [validate](./commands/validate.md) — el gate offline a correr en cada PR
+- [apply](./commands/apply.md) — `--dir`, `--dry-run` y `-y`
+- [Autenticación](./authentication.md) — cómo funcionan el login y los perfiles

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/ci-cd.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/ci-cd.md
@@ -25,19 +25,21 @@ Esta es la parte a hacer bien. En un pipeline no hay navegador para iniciar sesi
 
 </div>
 
-Hay dos formas de autenticarte en CI, según lo que soporte tu entorno:
+Tanto `cotctl login` (navegador) como `cotctl login --no-browser` (email/contraseña) son **interactivos** — abren un navegador o piden credenciales por prompt — así que por sí solos no sirven para un job desatendido. La forma confiable de autenticarte en CI es con un **API token pre-generado**.
 
-**Opción A — login con `--no-browser` usando credenciales secretas.** El enfoque más limpio cuando tenés una cuenta de servicio con email/contraseña:
+**1. Generá el token una vez.** Un administrador emite un API token desde el panel de administración de Cotalker (o el Partner Platform) y guardás su valor como un secret encriptado de CI — por ejemplo `COTCTL_API_TOKEN`.
+
+**2. Autenticate de forma no interactiva con `--paste-token`.** `cotctl login --paste-token` crea un perfil a partir de un token pre-generado en vez de pedir credenciales. En CI, pipeá el secret hacia él:
 
 ```bash
-cotctl login \
+echo "$COTCTL_API_TOKEN" | cotctl login \
   --url https://web.cotalker.com \
   --subdomain acme \
-  --no-browser
-# credenciales provistas vía las variables de entorno respaldadas por secrets de CI
+  --profile acme \
+  --paste-token
 ```
 
-**Opción B — proveer un token vía un secret.** Si generás un token por fuera, exponelo al job como una variable de entorno respaldada por un secret (por ejemplo `$COTCTL_TOKEN`) en vez de hardcodearlo. Referenciá la variable; nunca el valor literal.
+Nada queda hardcodeado, y no hay prompt interactivo que cuelgue el job.
 
 ## Un ejemplo trabajado (GitHub Actions)
 
@@ -68,15 +70,14 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     env:
-      COTCTL_EMAIL: ${{ secrets.COTCTL_EMAIL }}
-      COTCTL_PASSWORD: ${{ secrets.COTCTL_PASSWORD }}
+      COTCTL_API_TOKEN: ${{ secrets.COTCTL_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
       - run: npm install -g @cotctl/cli
-      - run: cotctl login --url https://web.cotalker.com --subdomain acme --no-browser
+      - run: echo "$COTCTL_API_TOKEN" | cotctl login --url https://web.cotalker.com --subdomain acme --profile acme --paste-token
       - run: cotctl apply --dir config/ -c acme -y
 ```
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/apply.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/apply.md
@@ -1,0 +1,183 @@
+---
+title: apply
+sidebar_label: apply
+displayed_sidebar: developer
+---
+
+`cotctl apply` es el comando que realmente modifica un entorno de Cotalker. Toma tu YAML y hace que la plataforma coincida con él — creando recursos que no existen y actualizando los que sí. Es el verbo que más vas a usar, así que vale la pena entenderlo bien.
+
+Hay dos formas de ejecutarlo, según si desplegás un archivo o una carpeta entera:
+
+| Modo | Flag | Propósito |
+|---|---|---|
+| Archivo único | `-f <file>` | Aplica un YAML de cualquier kind soportado |
+| Directorio | `--dir <path>` | Aplica todos los YAML de una carpeta, en el orden de dependencias correcto |
+
+<div className="alert alert--primary">
+
+**Siempre validá primero.** `apply` escribe en un entorno real. Hacé de `cotctl validate` (y `--dry-run`) parte de tu memoria muscular antes de cada apply — especialmente contra producción.
+
+</div>
+
+## Cómo apply decide qué hacer
+
+`apply` lee el campo `kind:` al inicio de tu YAML y rutea al manejador correcto. Hay siete kinds soportados:
+
+| `kind:` | Qué gestiona |
+|---|---|
+| `Survey` | Formularios |
+| `AccessRole` | Permisos |
+| `PropertyType` | Esquemas del modelo de datos |
+| `Property` | Instancias del modelo de datos |
+| `JobTitle` | Posiciones organizacionales (Cargos) |
+| `Workflow` | Procesos y máquinas de estado |
+| `User` | Personas |
+
+Si `kind:` falta o no se reconoce, `apply` se detiene y lista las opciones válidas (más la forma con alcance de entidad de cada una, como `cotctl roles apply`). Nunca adivina.
+
+**Crear vs. actualizar es automático.** `apply` busca el recurso por su `code` (o `name`). Si no existe, se crea; si existe, se actualiza. No elegís — solo describís el estado deseado.
+
+## Modo archivo único
+
+```bash
+cotctl apply -f <file.yaml> -c <profile> [options]
+```
+
+### Opciones
+
+| Opción | Descripción |
+|---|---|
+| `-f, --file <path>` | **(requerido)** Ruta al archivo YAML |
+| `-c, --company <profile>` | **(requerido)** Perfil a usar |
+| `--dry-run` | Valida y muestra lo que *se enviaría*, sin aplicar |
+| `-y, --yes` | Salta las confirmaciones (los warnings igual se imprimen a stderr) |
+| `--skip-semantic-validation` | **Solo Survey** — salta los checks semánticos |
+| `--skip-remote-validation` | **Solo Survey** — salta los checks remotos |
+
+### Ejemplos
+
+```bash
+# Crear o actualizar una encuesta
+cotctl apply -f my-survey.yaml -c acme
+
+# Previsualizar lo que se enviaría — no cambia nada
+cotctl apply -f my-survey.yaml -c acme --dry-run
+
+# Un workflow, un rol, un tipo de propiedad — mismo comando, distinto kind
+cotctl apply -f workflow.yaml -c acme
+cotctl apply -f role.yaml -c acme
+cotctl apply -f property-type.yaml -c acme
+```
+
+Un apply exitoso confirma lo que pasó:
+
+```
+Survey "my_survey" created successfully (id: 507f1f77bcf86cd799439011)
+```
+
+<div className="alert alert--info">
+
+**Nunca gestionás IDs a mano.** Al crear, no incluís `_id`/`id` — el backend los genera. Al actualizar, `cotctl` recupera el recurso existente y resuelve los IDs correctos por vos (haciendo match de las preguntas de la encuesta por su `identifier`). Tu YAML se mantiene limpio y legible.
+
+</div>
+
+### Qué podés cambiar al actualizar una encuesta
+
+Como las preguntas se matchean por `identifier`, no por posición, las ediciones se comportan de forma intuitiva:
+
+| Querés… | Hacé esto | Resultado |
+|---|---|---|
+| Agregar una pregunta | Agregala a `questions[]` | Creada |
+| Quitar una pregunta | Borrala de `questions[]` | Desactivada (no borrada), tras una confirmación |
+| Editar una pregunta | Cambiá sus campos, mantené el `identifier` | Actualizada, ID preservado |
+| Reordenar preguntas | Reordená `questions[]` | Cambia el orden, IDs preservados |
+
+Dos cosas son inmutables una vez creadas: el `code` de una encuesta, y el `identifier` de una pregunta. `apply` se negará a renombrar cualquiera de los dos — para "renombrar", creás un recurso nuevo. Y si aplicás un YAML de encuesta sin su sección `questions` (por ejemplo, para cambiar `isActive`), las preguntas existentes se preservan automáticamente.
+
+## Modo directorio
+
+Para cualquier cosa más allá de un solo archivo — y especialmente para un workflow scaffoldeado, que abarca roles, tipos de propiedad, propiedades y el workflow en sí — apuntá `apply` a la carpeta y dejá que maneje el orden:
+
+```bash
+cotctl apply --dir <path> -c <profile> [options]
+```
+
+### Por qué importa el orden (y por qué no tenés que pensarlo)
+
+Los recursos dependen entre sí: un workflow referencia roles y tipos de propiedad, que deben existir antes. `apply --dir` agrupa los documentos por kind y los aplica en este orden canónico automáticamente:
+
+| # | Entidad | Va primero porque… |
+|---|---|---|
+| 1 | AccessRole | Todo lo demás referencia permisos |
+| 2 | PropertyType | Fundamento del modelo de datos |
+| 3 | Property | Depende de PropertyType |
+| 4 | JobTitle | Depende de roles y el modelo de datos |
+| 5 | Workflow | Referencia roles, tipos de propiedad y propiedades |
+| 6 | Survey | Referenciada por transiciones del workflow |
+| 7 | User | Depende de cargos y roles |
+
+### Opciones
+
+| Opción | Descripción |
+|---|---|
+| `--dir <path>` | **(requerido)** Carpeta con archivos YAML |
+| `-c, --company <profile>` | **(requerido)** Perfil a usar |
+| `--dry-run` | Previsualiza cada payload sin aplicar |
+| `-y, --yes` | Salta todas las confirmaciones |
+| `--continue-on-error` | Sigue si una entidad falla (default: detenerse en el primer error) |
+
+### Ejemplo
+
+```bash
+# Previsualizar, luego aplicar
+cotctl apply --dir ordenes-compra/ -c dev --dry-run
+cotctl apply --dir ordenes-compra/ -c dev
+```
+
+```
+Applying directory: ordenes-compra/ → dev
+
+AccessRole (6 documents)
+  ✓ created  ordenes-compra:start-form
+  ...
+PropertyType (3 documents)
+  ✓ created  oc_transaccion
+  ...
+Workflow (1 document)
+  ✓ created  ordenes_compra
+
+─────────────────────────────────────────────────────────────────
+13 created, 0 updated, 0 errors
+```
+
+### Es seguro correrlo dos veces
+
+El apply de directorio es **idempotente** — re-ejecutarlo es esperado y seguro:
+
+| Escenario | Comportamiento |
+|---|---|
+| Entorno nuevo | Todo creado |
+| Re-apply, sin cambios | Todo actualizado (un no-op en la práctica) |
+| Re-apply con archivos nuevos | Lo existente actualizado, lo nuevo creado |
+| Estado quitado de un YAML de workflow | **Bloqueado** — se rechazan los estados faltantes |
+| Campo inmutable cambiado | **Bloqueado** — se aplica la inmutabilidad de `code`/`nameCode` |
+
+## Una palabra sobre rate limits y permisos
+
+El backend limita la tasa de escrituras (aproximadamente 20 por ventana de 5 segundos). En scripts de batch grandes, espaciá tus llamadas o manejá las respuestas `429`. Y si algún apply devuelve `403`, el usuario logueado no tiene el permiso de administración requerido — eso es un tema de permisos de Cotalker, no de la CLI.
+
+## El ciclo estándar
+
+En la práctica, desplegar un workflow se ve así:
+
+```bash
+cotctl validate --dir ordenes-compra/            # 1. detectar errores offline
+cotctl apply    --dir ordenes-compra/ -c dev     # 2. desplegar
+cotctl validate --workflow ordenes_compra -c dev # 3. check de preparación para producción
+```
+
+## Ver también
+
+- [validate](./validate.md) — siempre antes de apply
+- [scaffolding](./scaffolding.md) — generá la carpeta que consume `apply --dir`
+- [Referencia YAML de recursos](../resources/surveys.md) — el esquema de cada kind

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/export-import.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/export-import.md
@@ -1,0 +1,116 @@
+---
+title: Exportar e importar
+sidebar_label: Exportar e importar
+displayed_sidebar: developer
+---
+
+Hasta ahora hablamos de empujar YAML *hacia* un entorno. Con la misma frecuencia, vas a querer extraer configuración existente *de* uno — para poner bajo control de versiones la configuración existente de un cliente, copiar un recurso entre entornos, o simplemente ver cómo está construido algo. Ese ciclo — **exportar → editar → aplicar** — es uno de los patrones más útiles de `cotctl`.
+
+Esta página usa encuestas como ejemplo, porque tienen las opciones de exportación más ricas. La misma forma `list` / `get` / `export` / `apply` se repite en los otros grupos de entidades (`roles`, `property-types`, `properties`, `users`, `jobtitles`, `workflows`).
+
+<div className="alert alert--info">
+
+**Nota de nomenclatura.** Los viejos comandos `cotctl get surveys` y `cotctl export survey` fueron eliminados. Usá las formas con alcance de entidad — `cotctl surveys list`, `cotctl surveys export`, etc.
+
+</div>
+
+## Encontrar lo que hay: `list`
+
+Antes de exportar, normalmente necesitás encontrar el recurso. `list` muestra lo que existe, con búsqueda y paginación:
+
+```bash
+cotctl surveys list -c acme
+```
+
+```
+ID                         NAME                  CODE             VER   ACTIVE   MODIFIED
+-------------------------------------------------------------------------------------------
+507f1f77bcf86cd799439011   Order Request Form    order_request    3     true     2024-03-15
+507f1f77bcf86cd799439012   Approval Survey       approval_srv      1     true     2024-02-20
+```
+
+Opciones útiles: `-s/--search <text>` para filtrar por nombre o código, `--all` para incluir recursos inactivos, `-l/--limit` y `-p/--page` para paginar, y `--json` para salida procesable por máquina.
+
+## Mirar uno: `get`
+
+Para inspeccionar un único recurso sin escribir un archivo:
+
+```bash
+cotctl surveys get order_request -c acme
+```
+
+Agregá `--populate` para incluir la lista completa de preguntas (la salida pasa a YAML automáticamente, ya que una tabla no puede mostrar preguntas anidadas), o `-o json` para obtener JSON.
+
+## Extraerlo: `export`
+
+`export` es lo que trae un recurso como archivo YAML que podés versionar y volver a aplicar:
+
+```bash
+cotctl surveys export order_request -c acme -o ./order_request.yaml
+```
+
+<div className="alert alert--secondary">
+
+**`-o` es una ruta, no un formato.** Un error común al principio es `-o yaml`. El flag `-o`/`--output` es la *ruta de archivo* donde escribir; usá `--format` para elegir el formato. Pasar una palabra clave de formato a `-o` es un error inmediato con un mensaje que te lo indica exactamente.
+
+</div>
+
+Hay dos formatos de exportación disponibles:
+
+| `--format` | Descripción |
+|---|---|
+| `simplified` (default) | Legible para humanos, con un array `questions[]` limpio — lo que querés para control de versiones |
+| `raw` | La representación cruda de la API |
+
+```bash
+# YAML simplificado por defecto, impreso a stdout
+cotctl surveys export order_request -c acme
+
+# Formato raw, escrito a un archivo
+cotctl surveys export order_request -c acme --format raw -o ./order_request_raw.yaml
+```
+
+### Mantener los scripts fuera del YAML
+
+Las encuestas pueden llevar JavaScript inline (exec hooks). Para un control de versiones más limpio, `--extract-scripts <dir>` saca esos scripts a archivos separados y los reemplaza por referencias `file://` en el YAML:
+
+```bash
+cotctl surveys export order_request -c acme \
+  -o ./order_request.yaml \
+  --extract-scripts ./scripts/
+```
+
+Ahora el JavaScript vive en archivos `.js` reales que tu editor y Git pueden manejar correctamente.
+
+## El ciclo completo
+
+Juntando todo, el ciclo exportar–editar–aplicar se ve así:
+
+```bash
+# 1. Exportar el recurso en vivo
+cotctl surveys export order_request -c acme -o order_request.yaml
+
+# 2. Editar order_request.yaml en tu editor, commitearlo a Git
+
+# 3. Validar, luego aplicar el cambio de vuelta
+cotctl validate -f order_request.yaml
+cotctl apply -f order_request.yaml -c acme
+```
+
+Así es también como **promovés entre entornos** — exportás de staging, aplicás a producción (con el perfil `-c` correspondiente).
+
+## Desactivar en vez de eliminar
+
+Cotalker prefiere la desactivación por sobre el borrado definitivo. Para sacar de uso una encuesta sin perderla:
+
+```bash
+cotctl surveys deactivate order_request -c acme
+```
+
+Pone `isActive: false` tras una confirmación (`-y` salta la confirmación en scripts).
+
+## Ver también
+
+- [apply](./apply.md) — la otra mitad del ciclo
+- [validate](./validate.md) — revisá el YAML exportado antes de re-aplicar
+- [Referencia YAML de recursos](../resources/surveys.md) — qué contienen los archivos exportados

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/login-logout.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/login-logout.md
@@ -1,0 +1,87 @@
+---
+title: login y logout
+sidebar_label: login y logout
+displayed_sidebar: developer
+---
+
+Estos dos comandos abren y cierran tu conexión con un entorno de Cotalker. Si ya leíste la página de [Autenticación](../authentication.md), ya conociste `login` — esta página es la referencia completa de ambos comandos, incluyendo cada opción y los casos menos comunes, como los entornos on-premise.
+
+## `cotctl login`
+
+`login` te autentica contra un entorno de Cotalker y guarda el resultado como un **perfil** reutilizable en `~/.cotctl/config.json`. Normalmente lo ejecutás una vez por entorno.
+
+```bash
+cotctl login --url <webclient-url> --subdomain <subdomain> [options]
+```
+
+Lo clave a recordar: `--url` es la dirección del **webclient** (lo que escribirías en un navegador), no una URL de API. `cotctl` descubre la API automáticamente a partir de eso.
+
+### Opciones
+
+| Opción | Requerido | Default | Descripción |
+|---|---|---|---|
+| `--url` | Sí | — | URL del webclient del entorno |
+| `--subdomain` | Sí | — | Subdominio de la empresa |
+| `--api-url` | No | Autodetectada | Sobrescritura manual de la URL de API |
+| `--no-browser` | No | `false` | Usa email/contraseña en vez del navegador |
+| `--profile` | No | Valor de `--subdomain` | Nombre de perfil personalizado |
+
+### Flujo con navegador (el default)
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain acme
+```
+
+Esto abre tu navegador en la página de autenticación de Cotalker, aprobás el acceso, y el token se devuelve a la CLI. El flujo expira a los 5 minutos si no lo completás.
+
+### Login con email/contraseña
+
+Cuando no hay navegador disponible — un servidor, un runner de CI — agregá `--no-browser` y se te pedirán las credenciales en la terminal:
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain acme --no-browser
+```
+
+### Entornos on-premise
+
+La mayoría de los entornos exponen un archivo de variables que le permite a `cotctl` autodescubrir la URL de la API. Si un cliente corre Cotalker en su propia infraestructura y ese descubrimiento falla, apuntá `cotctl` a la API explícitamente con `--api-url`:
+
+```bash
+cotctl login \
+  --url https://cotalker.empresa.com \
+  --subdomain emp \
+  --api-url https://api.empresa.com
+```
+
+<div className="alert alert--info">
+
+**Dónde viven las credenciales.** El perfil se escribe en `~/.cotctl/config.json` con permisos de archivo restrictivos (`0600`). No hay token que copiar ni guardar vos mismo.
+
+</div>
+
+### Una nota sobre permisos
+
+Para aplicar recursos (encuestas, workflows, etc.) necesitás permisos de administración en Cotalker. Si más adelante un comando devuelve un `403`, es la plataforma diciéndote que el usuario logueado no tiene el permiso requerido — pedile al administrador de la empresa que lo otorgue.
+
+## `cotctl logout`
+
+`logout` quita las credenciales de un perfil de tu archivo de configuración local.
+
+```bash
+cotctl logout <profile>
+# o, equivalentemente:
+cotctl logout -c <profile>
+```
+
+El argumento posicional `<profile>` es opcional si en su lugar pasás `-c <profile>`.
+
+<div className="alert alert--secondary">
+
+**Matiz importante.** `logout` solo quita el perfil *localmente* — **no** invalida el token en el servidor de Cotalker. Es equivalente a [`cotctl profile delete`](./profiles.md). Para revocar realmente un token del lado del servidor, hacelo desde la interfaz web de Cotalker.
+
+</div>
+
+## Ver también
+
+- [Autenticación](../authentication.md) — el recorrido conceptual de perfiles y el flag `-c`
+- [Gestionar perfiles](./profiles.md) — listar y eliminar perfiles guardados

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/login-logout.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/login-logout.md
@@ -77,7 +77,7 @@ El argumento posicional `<profile>` es opcional si en su lugar pasás `-c <profi
 
 <div className="alert alert--secondary">
 
-**Matiz importante.** `logout` solo quita el perfil *localmente* — **no** invalida el token en el servidor de Cotalker. Es equivalente a [`cotctl profile delete`](./profiles.md). Para revocar realmente un token del lado del servidor, hacelo desde la interfaz web de Cotalker.
+**`logout` revoca tu token en el servidor.** Para los perfiles modernos de tipo API-token, `cotctl logout` **revoca el ApiToken en el servidor de Cotalker** y luego quita el perfil local, así el token ya no puede usarse. (Los perfiles JWT legacy no tienen nada que revocar — simplemente expiran — así que solo se quitan localmente.) Esta es la diferencia clave con [`cotctl profile delete`](./profiles.md), que quita el perfil **solo localmente** y deja cualquier token válido.
 
 </div>
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/profiles.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/profiles.md
@@ -1,0 +1,49 @@
+---
+title: Gestionar perfiles
+sidebar_label: profile
+displayed_sidebar: developer
+---
+
+Un **perfil** es una conexión guardada a un entorno de Cotalker — creada cada vez que ejecutás [`cotctl login`](./login-logout.md). Como partner que trabaja entre staging, producción y varios clientes, vas a acumular unos cuantos. El comando `cotctl profile` es cómo los ves y ordenás.
+
+## `cotctl profile list`
+
+Muestra cada perfil que guardaste, con el entorno y el usuario detrás de cada uno:
+
+```bash
+cotctl profile list
+```
+
+```
+NAME          URL                              SUBDOMAIN    USER
+acme          https://www.cotalker.com         acme         admin@acme.com
+devteam       https://staging.cotalker.com     devteam      dev@cotalker.com
+```
+
+Este es el comando al que recurrir cuando no estés seguro de qué nombre de perfil pasarle a `-c`, o quieras confirmar como qué usuario está autenticado un perfil.
+
+## `cotctl profile delete`
+
+Quita un perfil de tu archivo de configuración local:
+
+```bash
+cotctl profile delete <name>
+```
+
+<div className="alert alert--secondary">
+
+**Solo local.** Eliminar un perfil lo quita de `~/.cotctl/config.json` pero **no** invalida el token en el servidor — exactamente igual que [`cotctl logout`](./login-logout.md). Los dos comandos son equivalentes. Para revocar un token del lado del servidor, usá la interfaz web de Cotalker.
+
+</div>
+
+## El flag `-c`, una vez más
+
+Todo comando que habla con la API requiere `-c <profile>` para seleccionar sobre qué entorno actuar — no hay default, a propósito. `cotctl profile list` es cómo encontrás el nombre exacto a usar:
+
+```bash
+cotctl apply -f survey.yaml -c staging
+cotctl surveys list -c production
+cotctl surveys export my_survey -c staging
+```
+
+Si alguna vez ves `Error: --company/-c is required`, ejecutá `cotctl profile list` para elegir el nombre correcto.

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/profiles.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/profiles.md
@@ -32,7 +32,7 @@ cotctl profile delete <name>
 
 <div className="alert alert--secondary">
 
-**Solo local.** Eliminar un perfil lo quita de `~/.cotctl/config.json` pero **no** invalida el token en el servidor — exactamente igual que [`cotctl logout`](./login-logout.md). Los dos comandos son equivalentes. Para revocar un token del lado del servidor, usá la interfaz web de Cotalker.
+**Solo local — esto *no* revoca el token.** Eliminar un perfil lo quita de `~/.cotctl/config.json` pero deja cualquier token válido en el servidor. Es distinto de [`cotctl logout`](./login-logout.md), que revoca el ApiToken en el servidor (para perfiles API-token) antes de quitar el perfil. Usá `profile delete` cuando solo querés olvidar un perfil; usá `logout` cuando también querés invalidar su token.
 
 </div>
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/scaffolding.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/scaffolding.md
@@ -1,0 +1,95 @@
+---
+title: Scaffolding de un workflow
+sidebar_label: Scaffolding
+displayed_sidebar: developer
+---
+
+Construir un workflow desde un archivo en blanco es mucho boilerplate: necesitás roles, tipos de propiedad, propiedades de estado y el workflow en sí, todo nombrado consistentemente y conectado entre sí. `cotctl workflows scaffold` genera ese esqueleto por vos — correctamente nombrado y listo para personalizar — así arrancás desde una estructura que funciona en vez de una página en blanco.
+
+Es un comando offline. No se toca ningún entorno hasta que hacés `apply` más tarde.
+
+## El comando
+
+```bash
+cotctl workflows scaffold --name <flow-name> --code <prefix> [options]
+```
+
+Dos entradas son requeridas:
+
+- `--name` — el nombre del flujo en kebab-case, ej. `ordenes-compra`.
+- `--code` — un prefijo corto de 2–4 letras usado en todos los códigos generados, ej. `oc`.
+
+```bash
+cotctl workflows scaffold --name ordenes-compra --code oc
+```
+
+### Opciones
+
+| Opción | Descripción |
+|---|---|
+| `--name <name>` | **(requerido)** Nombre del flujo, kebab-case |
+| `--code <prefix>` | **(requerido)** 2–4 letras minúsculas |
+| `--display <name>` | Nombre legible (default: `--name` con mayúsculas iniciales) |
+| `--output-dir <dir>` | Dónde escribir (default: `./<name>/`) |
+| `--states <list>` | Estados cerrados extra más allá de los tres base, separados por coma |
+| `--no-technical` | Omite los permisos técnicos (`form-bypass`, `force-state`) |
+
+## Qué genera
+
+Un scaffold es una pequeña carpeta de YAML, organizada por concern:
+
+```
+ordenes-compra/
+├── README.md                  # Definición del flujo, convenciones de nombres, orden de apply
+├── workflow.yaml              # Workflow + máquina de estado + transiciones
+├── access/
+│   ├── permissions.yaml       # Un AccessRole por permiso
+│   └── manager-role.yaml      # Rol Manager que agrega todos los permisos
+└── data-model/
+    ├── property-types.yaml    # transaccion, maestro, estados
+    └── states.yaml            # estados base: borrador, pendiente, error
+```
+
+De fábrica obtenés seis roles de acceso (cuatro con `--no-technical`), un rol Manager, tres tipos de propiedad, tres estados base (un estado *nuevo*, uno *en progreso* y uno *de error*) y un workflow con su máquina de estado. Todo sigue las convenciones de nombres de implementación de Cotalker, así que el resultado pasa los checks de nomenclatura de [`cotctl validate --workflow`](./validate.md#modo-workflow--preparación-para-producción-online) desde el principio.
+
+### Agregar tus propios estados
+
+La mayoría de los flujos reales necesita más de los tres estados base. Pasalos con `--states` y `cotctl` genera las propiedades de estado y conecta transiciones desde `pendiente` a cada uno:
+
+```bash
+cotctl workflows scaffold --name ordenes-compra --code oc \
+  --display "Órdenes de Compra" \
+  --states aprobado,rechazado,cerrado
+```
+
+## El pipeline en el que encaja
+
+El scaffolding es el paso 1 de un ciclo de cinco pasos. Los pasos 2–5 se repiten con seguridad a medida que iterás, porque cada apply es idempotente:
+
+```
+1. scaffold   →  cotctl workflows scaffold --name ordenes-compra --code oc
+2. customize  →  editá el YAML — agregá propiedades, formularios, lógica de negocio
+3. validate   →  cotctl validate --dir ordenes-compra/
+4. apply      →  cotctl apply --dir ordenes-compra/ -c dev
+5. validate   →  cotctl validate --workflow ordenes_compra -c dev
+```
+
+<div className="alert alert--primary">
+
+**El modelo mental.** Scaffold te da un *esqueleto correcto*. Después lo completás (paso 2), lo revisás offline (paso 3), lo desplegás (paso 4) y confirmás que está listo para producción contra el entorno en vivo (paso 5) — iterando sobre 2–5 hasta quedar conforme.
+
+</div>
+
+## Un par de reglas de entrada
+
+`cotctl` valida tus entradas de antemano para que los nombres generados sean siempre válidos:
+
+- `--name` debe ser kebab-case (ej. `ordenes-compra`).
+- `--code` debe ser de 2–4 letras minúsculas.
+- `--output-dir` no debe existir ya (así nunca sobrescribís trabajo).
+
+## Ver también
+
+- [validate](./validate.md) — revisá el scaffold offline, luego contra el workflow en vivo
+- [apply](./apply.md) — desplegá la carpeta entera con `--dir`
+- [Referencia YAML de workflows](../resources/workflows.md) — entendé lo que estás personalizando

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/validate.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/commands/validate.md
@@ -1,0 +1,120 @@
+---
+title: validate
+sidebar_label: validate
+displayed_sidebar: developer
+---
+
+`cotctl validate` revisa tu YAML *antes* de desplegarlo. Tomar el hábito de validar primero es una de las cosas de mayor valor que podés hacer como partner: detecta errores en tu máquina, en segundos, en vez de como un cambio a medio aplicar en el entorno de un cliente.
+
+Hay tres cosas que podrías querer validar, y `validate` tiene un modo para cada una:
+
+| Modo | Flag | Red | Para qué sirve |
+|---|---|---|---|
+| Archivo | `-f <file>` | Offline | Revisar un único archivo YAML de encuesta |
+| Directorio | `--dir <path>` | Offline | Verificación cruzada de una carpeta entera antes de `apply --dir` |
+| Workflow | `--workflow <nameCode>` | Online | Correr el checklist de preparación para producción contra un workflow en vivo |
+
+## Modo archivo — una encuesta, offline
+
+La verificación más rápida. Valida un único YAML de encuesta contra el esquema, sin llamada a la API:
+
+```bash
+cotctl validate -f my-survey.yaml
+```
+
+```
+✓ my-survey.yaml is valid
+```
+
+Si algo está mal, te dice qué y dónde:
+
+```
+✗ my-survey.yaml has validation errors:
+
+  - code: code must start with a lowercase letter and contain only lowercase letters, numbers, and underscores
+```
+
+Por debajo corren tres capas de verificación:
+
+| Capa | Qué revisa | Cómo saltarla |
+|---|---|---|
+| Estructura (Zod) | Tipos, campos requeridos, enums | Siempre activa |
+| Semántica | `function run()` en exec hooks, botones en la etapa equivocada, campos deprecados | `--skip-semantic-validation` |
+| Remota | Unicidad de identificadores en la empresa, que las entidades referenciadas existan | Requiere `--remote` + `-c <profile>` |
+
+Las dos primeras son offline. Las verificaciones remotas llegan a la API, así que requieren un perfil:
+
+```bash
+cotctl validate -f my-survey.yaml --remote -c acme
+```
+
+## Modo directorio — una carpeta entera, offline
+
+Este es el que más vas a usar al trabajar con workflows scaffoldeados. Valida cada archivo YAML de una carpeta **y** revisa que se referencien entre sí correctamente — todo offline. Ejecutalo justo antes de `apply --dir`:
+
+```bash
+cotctl validate --dir ordenes-compra/
+```
+
+Corre dos familias de checks. **Checks de esquema**, por archivo:
+
+| ID | Check |
+|---|---|
+| S1 | El archivo parsea como YAML válido |
+| S2 | `kind` está presente y es reconocido |
+| S3 | El documento valida contra el esquema de su `kind` |
+
+Y **checks de referencias cruzadas**, entre archivos — esto es lo que detecta una propiedad apuntando a un tipo de propiedad inexistente:
+
+| ID | Severidad | Check |
+|---|---|---|
+| X1 | warn | Las cadenas de permiso (`name:action`) están definidas como AccessRoles |
+| X2 | fail | `Property.propertyType` referencia un PropertyType existente |
+| X3 | fail | Las referencias de `propertyType` de la máquina de estado del workflow resuelven |
+| X4 | fail | `states[].property` del workflow referencia una Property existente |
+| X5 | fail | El `initialState` de la máquina de estado referencia una Property existente |
+| X6 | warn | Los permisos del workflow están definidos como AccessRoles |
+
+Una corrida limpia termina con un veredicto claro:
+
+```
+Results: 11 PASS, 0 WARN, 0 FAIL — ready to apply
+```
+
+Agregá `--json` si querés consumir el resultado en un script.
+
+## Modo workflow — preparación para producción, online
+
+Una vez que un workflow está en vivo, este modo corre el checklist de **Marcha Blanca** (puesta en producción) contra él. Es un check online, así que necesita un perfil:
+
+```bash
+cotctl validate --workflow ordenes_compra -c prod
+```
+
+El checklist está organizado en tres secciones, y podés correr solo una con `--section`:
+
+- **Nomenclatura** (`nomenclature`) — convenciones de nombres para códigos, formularios, propiedades y permisos.
+- **Permisos** (`permissions`) — que exista un rol Manager con todos los permisos del flujo, conectado a los formularios vinculados.
+- **Configuración** (`configuration`) — reglas técnicas, como que los campos de control sean de solo lectura y que exista un estado de error.
+
+```bash
+# solo los checks de nomenclatura
+cotctl validate --workflow ordenes_compra --section nomenclature -c prod
+```
+
+```
+Results: 13 PASS, 1 WARN, 0 FAIL — production ready
+```
+
+Los checks se califican **WARN** (una recomendación) o **FAIL** (un problema real). El comando sale con `0` cuando todo pasa o solo hay warnings, y con `1` cuando al menos un check falla — que es justo lo que querés como gate en un pipeline.
+
+<div className="alert alert--info">
+
+**Un par de límites conocidos.** Los checks profundos de calidad de código JavaScript sobre exec hooks no están implementados, y el check de estado de error (T3) busca la convención de nombres `_estado_error` — si tu implementación nombra su estado de error de otra forma, esperá un warning aunque exista un estado de error.
+
+</div>
+
+## Ver también
+
+- [apply](./apply.md) — desplegá tus recursos una vez que la validación pasa
+- [scaffolding](./scaffolding.md) — generá un esqueleto de workflow para validar y aplicar

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/demo-company.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/demo-company.md
@@ -1,0 +1,73 @@
+---
+title: Practicá primero en una compañía demo
+sidebar_label: Compañía demo
+displayed_sidebar: developer
+---
+
+Antes de apuntar `cotctl` al entorno de un cliente real, hacete un favor: **practicá primero en una compañía demo.** Este único hábito es la mejor forma de aprender la herramienta con cero riesgo — tu primer caso real nunca debería ser una compañía productiva.
+
+## Por qué importa
+
+`cotctl apply` hace cambios reales en un entorno real. Mientras todavía estás aprendiendo — agarrándole la mano a los perfiles, al ciclo validate → apply, a scaffoldear un workflow, a ver cómo se ve un error — querés un lugar donde los errores no cuesten nada. Una **compañía demo** es exactamente eso: un entorno descartable donde podés experimentar libremente, romper cosas, empezar de nuevo y ganar confianza antes de que nada toque a un cliente en vivo.
+
+<div className="alert alert--primary">
+
+**La regla práctica.** Tu *primera* corrida de punta a punta de cualquier flujo nuevo — y tu *primera* vez usando `cotctl` — debería ser en una compañía demo o sandbox, nunca en producción. Graduate a entornos reales solo cuando los pasos te salgan solos.
+
+</div>
+
+## Conseguir una compañía demo
+
+Las compañías nuevas se crean a través del **Partner Platform de Cotalker** — la aplicación web de super-admin para gestionar organizaciones en el ecosistema de Cotalker, donde crear y configurar una compañía nueva es una capacidad incorporada.
+
+- **Si tenés acceso de super-usuario al Partner Platform**, creá ahí una compañía demo nueva y usala como tu sandbox.
+- **Si no**, pedile a tu contacto de Cotalker que te aprovisione una compañía demo/sandbox. Para el onboarding de partners suele ser ideal, ya que puede venir pre-cargada para parecerse a una implementación real.
+
+De cualquier forma, el objetivo es el mismo: una compañía no productiva que controlás por completo.
+
+## Conectar cotctl a ella
+
+Una vez que tenés una compañía demo, logueate igual que a cualquier otro entorno — simplemente se vuelve otro perfil. Darle un nombre obvio (como `demo`) hace que sea difícil confundirla con el entorno de un cliente más adelante:
+
+```bash
+cotctl login --url https://web.cotalker.com --subdomain my-demo --profile demo
+```
+
+De ahí en más, todo lo que practiques corre contra `-c demo`:
+
+```bash
+cotctl validate --dir ordenes-compra/
+cotctl apply    --dir ordenes-compra/ -c demo
+cotctl validate --workflow ordenes_compra -c demo
+```
+
+<div className="alert alert--info">
+
+**El flag `-c` es tu red de seguridad.** Como cada comando te obliga a nombrar la compañía explícitamente, la única forma de que un cambio llegue a producción es que *escribas* un perfil de producción. Mantener un perfil `demo` claramente nombrado vuelve obvia la opción segura. Mirá [Autenticación](./authentication.md) para ver cómo funcionan los perfiles.
+
+</div>
+
+## Una primera corrida sugerida
+
+Una gran forma de estrenar tu compañía demo es hacer la receta completa de workflow de punta a punta — generar un scaffold, validarlo, aplicarlo, y correr el check de preparación para producción — todo contra `-c demo`:
+
+```bash
+cotctl workflows scaffold --name ordenes-compra --code oc --display "Órdenes de Compra"
+cotctl validate --dir ordenes-compra/
+cotctl apply    --dir ordenes-compra/ -c demo
+cotctl validate --workflow ordenes_compra -c demo
+```
+
+Nada acá puede dañar a un cliente — así que experimentá, inspeccioná el resultado en la UI de la compañía demo, ajustá el YAML, y re-aplicá tantas veces como quieras.
+
+## Graduarte a entornos reales
+
+Una vez que estés cómodo, el trabajo real son los mismos comandos con un perfil distinto. Una progresión sana es:
+
+**demo → staging → producción** — probá un cambio en tu compañía demo, promovelo al entorno de staging de un cliente, y recién después a producción. El flujo de [exportar e importar](./commands/export-import.md) es cómo llevás el mismo YAML a través de esos entornos.
+
+## Próximos pasos
+
+- [Tutoriales](./tutorials.md) — corré estos primero en tu compañía demo
+- [Autenticación](./authentication.md) — perfiles y el flag `-c`
+- [apply](./commands/apply.md) — lo que realmente cambia un entorno

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/installation.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/installation.md
@@ -1,0 +1,82 @@
+---
+title: Instalación
+sidebar_label: Instalación
+displayed_sidebar: developer
+---
+
+En esta página vas a instalar `cotctl` en tu máquina y confirmar que funciona. Toma unos dos minutos. Si alguna vez instalaste un paquete global de npm, esto te va a resultar familiar.
+
+## Antes de empezar: los requisitos
+
+Hay dos cosas que necesitás tener:
+
+- **Node.js versión 22.0.0 o superior.** `cotctl` se distribuye como paquete npm y corre sobre Node. Para verificar si lo tenés — y qué versión — ejecutá:
+
+  ```bash
+  node --version
+  ```
+
+  Si el comando no se encuentra, o el número es menor a `22`, instalá o actualizá Node primero desde [nodejs.org](https://nodejs.org). Recomendamos la versión LTS.
+
+- **Acceso de administrador a la empresa de Cotalker que querés gestionar.** La mayoría de los comandos de `cotctl` leen y escriben configuración, lo que requiere permisos de administrador en el entorno destino.
+
+<div className="alert alert--info">
+
+**¿Todavía no tenés acceso de administrador?** Está bien para instalar la herramienta — todo lo de esta página lo podés hacer sin eso. Pero lo vas a necesitar antes del paso de [Autenticación](./authentication.md), así que conviene pedirlo al administrador de Cotalker de la empresa desde ya.
+
+</div>
+
+## Instalar la herramienta
+
+La forma recomendada es instalarla **globalmente**, lo que deja el comando `cotctl` disponible en toda tu máquina:
+
+```bash
+npm install -g @cotctl/cli
+```
+
+El flag `-g` es lo que la hace global. Cuando termine, podés ejecutar `cotctl` desde cualquier carpeta.
+
+### ¿Preferís no instalarla globalmente?
+
+Si solo la necesitás ocasionalmente, o querés fijar una versión por proyecto, podés ejecutarla bajo demanda con `npx` — esto la descarga y ejecuta sin instalación permanente:
+
+```bash
+npx @cotctl/cli <command> [options]
+```
+
+A lo largo de esta guía escribimos los comandos como `cotctl ...`. Si usás `npx`, simplemente reemplazá eso por `npx @cotctl/cli ...`.
+
+## Confirmar que funcionó
+
+Asegurémonos de que la instalación fue exitosa. Pedile a la herramienta su versión:
+
+```bash
+cotctl --version
+```
+
+Deberías ver un número de versión, por ejemplo:
+
+```
+0.8.0
+```
+
+Si ves una versión, listo — la herramienta está instalada correctamente. Si en cambio obtenés un error "command not found", puede que el directorio de binarios globales de npm no esté en tu `PATH`; la página de [Solución de problemas](./troubleshooting.md) explica cómo resolverlo.
+
+## Orientándote
+
+Hay dos comandos que conviene conocer desde el principio. La forma general de toda invocación de `cotctl` es:
+
+```bash
+cotctl <command> [options]
+```
+
+Y cada vez que no sepas qué hay disponible o qué espera un comando, agregá `--help`:
+
+```bash
+cotctl --help            # lista todos los comandos
+cotctl apply --help      # opciones de un comando específico
+```
+
+## Próximo paso
+
+`cotctl` está instalado, pero todavía no conoce ningún entorno de Cotalker. Arreglemos eso en [**Autenticación**](./authentication.md), donde lo vas a conectar a una empresa y aprender cómo funcionan los perfiles.

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/mcp-integration.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/mcp-integration.md
@@ -1,0 +1,59 @@
+---
+title: MCP e integración con IA
+sidebar_label: Integración MCP
+displayed_sidebar: developer
+---
+
+`cotctl` puede conectar asistentes de IA — como Claude — a la documentación técnica de Cotalker, de modo que mientras creás recursos puedas hacer preguntas y obtener respuestas fundamentadas en la documentación real y actualizada. Esta página explica la idea y cómo configurarla.
+
+## ¿Qué es MCP, y por qué le importaría a un partner?
+
+**MCP** (Model Context Protocol) es una forma estándar de darle a un asistente de IA acceso a una fuente externa de conocimiento o herramientas. Cotalker expone un servidor MCP respaldado por su documentación, así un asistente conectado a él puede responder "¿cómo estructuro una transición de workflow?" o "¿qué campos toma un tipo de propiedad?" usando el material de referencia real en vez de adivinar.
+
+Para un partner que crea YAML, eso significa ayuda más rápida y precisa dentro de tu editor o herramienta de IA — menos idas y vueltas a la documentación, menos nombres de campo inventados.
+
+## Registrar el servidor
+
+El camino más simple es el comando gestionado, que te guía en la conexión y te deja elegir qué conjuntos de documentación incluir:
+
+```bash
+cotctl mcp install
+```
+
+<div className="alert alert--info">
+
+**¿Dónde está el endpoint?** La URL del endpoint MCP es específica de tu entorno de Cotalker — tu contacto de Cotalker te la puede proveer. `cotctl mcp install` maneja los detalles de conexión por vos, así que el comando gestionado es la ruta recomendada.
+
+</div>
+
+Si preferís registrarlo manualmente con un cliente compatible con MCP, la forma es un transporte HTTP que apunta al endpoint de documentación:
+
+```bash
+# Reemplazá la URL por el endpoint MCP de documentación de tu entorno
+claude mcp add --transport http cotalker-docs https://<your-cotalker-docs-endpoint>/mcp
+```
+
+## Enfocarte en documentación específica
+
+Un único endpoint puede servir varios conjuntos de documentación ("índices"). Podés acotar una conexión solo a los que te importan con un parámetro de query `?indices=` — por ejemplo, para consultar solo la documentación de la CLI:
+
+```bash
+claude mcp add --transport http cotalker-cli \
+  "https://<your-cotalker-docs-endpoint>/mcp?indices=cotctl"
+```
+
+También podés registrar **múltiples** servidores, cada uno acotado a un conjunto distinto — uno para la CLI, otro para la API y los modelos de datos — de modo que el asistente rutee cada pregunta a la fuente más relevante:
+
+```bash
+claude mcp add --transport http cotalker-cli \
+  "https://<your-cotalker-docs-endpoint>/mcp?indices=cotctl"
+claude mcp add --transport http cotalker-api \
+  "https://<your-cotalker-docs-endpoint>/mcp?indices=cot-api,cot-models"
+```
+
+Cada servidor registrado anuncia qué cubre, que es cómo el asistente decide dónde buscar.
+
+## Ver también
+
+- [Visión general](./overview.md) — qué es `cotctl` y cómo encajan las piezas
+- [Referencia YAML de recursos](./resources/surveys.md) — la documentación que el servidor MCP hace consultable

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/overview.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/overview.md
@@ -3,8 +3,6 @@ title: CLI de Cotalker (cotctl)
 sidebar_label: Visión general
 displayed_sidebar: developer
 ---
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import Highlight from '@theme/Highlight';
 
 <span className="hero__title">CLI de Cotalker — cotctl</span>
 <br/>

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/overview.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/overview.md
@@ -1,0 +1,88 @@
+---
+title: CLI de Cotalker (cotctl)
+sidebar_label: Visión general
+displayed_sidebar: developer
+---
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import Highlight from '@theme/Highlight';
+
+<span className="hero__title">CLI de Cotalker — cotctl</span>
+<br/>
+<br/>
+
+_¡Bienvenido! Esta guía te lleva desde cero hasta desplegar tu primera configuración de Cotalker desde la línea de comandos. Está escrita para **partners de implementación** — los consultores técnicos y desarrolladores que construyen soluciones sobre Cotalker — y no asume experiencia previa con la CLI._
+
+## ¿Qué es cotctl y por qué usarlo?
+
+Cuando configurás Cotalker desde el panel de administración web, hacés clic en formularios para crear encuestas, workflows, roles, etc. Eso funciona bien para cambios puntuales, pero tiene límites: los cambios no quedan versionados, son difíciles de reproducir entre entornos y no se pueden automatizar.
+
+`cotctl` resuelve eso. Es una **herramienta de línea de comandos que gestiona los recursos de Cotalker de forma declarativa a partir de archivos YAML** — muy parecido a cómo `kubectl` gestiona Kubernetes, o Terraform gestiona infraestructura. En vez de hacer clics, *describís* el recurso que querés en un archivo de texto, y `cotctl` hace que la plataforma coincida con esa descripción.
+
+En la práctica, esto te da cuatro cosas que importan cuando entregás proyectos para clientes:
+
+- **Declarativo.** Escribís *qué querés* (una encuesta con estas preguntas, un workflow con estos estados) y `cotctl apply` decide si crearlo o actualizarlo. No gestionás el "cómo".
+- **Versionable.** Tu YAML vive en tu propio repositorio Git. Cada cambio en la configuración de un cliente es revisable en un pull request y reversible con un `git revert`.
+- **Reproducible.** Los mismos archivos se despliegan primero a staging y luego a producción, contra cualquier empresa a la que tengas acceso. Se acabó el "funcionaba en la demo".
+- **Automatizable.** Al ser un comando, corre desatendido en un pipeline de CI/CD — los despliegues se vuelven repetibles y no dependen de que alguien recuerde los pasos.
+
+<div className="alert alert--primary">
+
+**El modelo mental.** Una empresa en Cotalker es un conjunto de *recursos* (encuestas, workflows, propiedades, roles, usuarios…). Con `cotctl` mantenés una descripción YAML de esos recursos en Git y los aplicás (`apply`) a un entorno. El YAML es la fuente de verdad; el entorno es el resultado.
+
+</div>
+
+## Qué podés gestionar
+
+Casi todo bloque de construcción que ensamblás durante una implementación tiene su representación en `cotctl`:
+
+| Recurso | Qué es | Grupo de comandos |
+|---|---|---|
+| **Encuestas** | Formularios para capturar datos | `cotctl surveys`, `cotctl apply` |
+| **Workflows** | Procesos y sus máquinas de estado | `cotctl workflows`, `cotctl workflows scaffold` |
+| **Tipos de propiedad y propiedades** | El modelo de datos (entidades y sus campos) | `cotctl property-types`, `cotctl properties` |
+| **Roles de acceso** | Permisos y qué puede ver/hacer cada rol | `cotctl roles` |
+| **Usuarios** | Personas de la empresa, con su jerarquía | `cotctl users` |
+| **Cargos (Job titles)** | Posiciones organizacionales | `cotctl jobtitles` |
+
+No te preocupes por aprenderlos todos de una. La mayoría de los partners empieza con encuestas y workflows, y va sumando el resto según lo pidan los proyectos.
+
+## Una probada de 60 segundos
+
+Este es el camino más corto desde la nada hasta un cambio desplegado. Explicamos cada paso en detalle en las páginas siguientes — esto es solo para que veas la forma:
+
+```bash
+# 1. Instalar la herramienta (una vez por máquina)
+npm install -g @cotctl/cli
+
+# 2. Conectarla a un entorno. Esto guarda un "perfil" reutilizable llamado acme.
+cotctl login --url https://web.cotalker.com --subdomain acme
+
+# 3. Desplegar un recurso. El flag -c le dice a cotctl sobre qué empresa actuar.
+cotctl apply -f my-survey.yaml -c acme
+```
+
+Ese es el ciclo completo: **instalar → login → apply.** Todo lo demás en esta guía hace cada uno de esos pasos más potente y más seguro.
+
+## Cómo está organizada esta guía
+
+Recomendamos leer las tres primeras páginas en orden — te dejan listo y productivo:
+
+1. [**Instalación**](./installation.md) — poné `cotctl` en tu máquina y confirmá que funciona.
+2. [**Autenticación**](./authentication.md) — conectate a un entorno y entendé los perfiles y el importantísimo flag `-c`.
+3. [**Practicá en una compañía demo**](./demo-company.md) — armá un entorno seguro, no productivo, para que tu primer caso real no sea la compañía en vivo de un cliente.
+4. [**Comandos**](./commands/apply.md) — los verbos del día a día: `apply`, `validate`, exportar/importar y scaffolding.
+
+Después, recurrí a estas cuando las necesites:
+
+- [**Referencia YAML de recursos**](./resources/surveys.md) — el esquema exacto de cada tipo de recurso.
+- [**Tutoriales**](./tutorials.md) — recetas completas, de punta a punta, para seguir paso a paso.
+- [**Solución de problemas**](./troubleshooting.md) — qué significan los errores comunes y cómo resolverlos.
+- [**CI/CD**](./ci-cd.md) — correr `cotctl` en pipelines automatizados.
+
+<div className="alert alert--secondary">
+
+**Una nota sobre los códigos de salida.** `cotctl` devuelve `0` cuando todo salió bien y `1` ante cualquier error (un problema de validación, un error de API, un perfil inexistente o un archivo faltante). Todavía no lo necesitás, pero es lo que vuelve a `cotctl` seguro de usar en scripts y gates de CI más adelante.
+
+</div>
+
+¿Listo? Vamos a [instalarlo](./installation.md).

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/jobtitles.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/jobtitles.md
@@ -1,0 +1,83 @@
+---
+title: Cargos (YAML)
+sidebar_label: Cargos
+displayed_sidebar: developer
+---
+
+Un **cargo** (Job title) es el puente entre una persona y lo que puede hacer. Vincula un [usuario](./users.md) a un conjunto de [roles de acceso](./roles.md), extensiones de tipo de propiedad y propiedades heredadas. Asignale un cargo a un usuario, y hereda todo lo que el cargo otorga. Como los cargos dependen de roles y del modelo de datos, se aplican después de esos — y antes que los usuarios.
+
+## La forma de un cargo
+
+```yaml
+kind: JobTitle
+code: store_manager
+display: "Jefe de Tienda"
+isActive: true
+accessRoles:
+  - "ordenes-compra:manager"
+  - "ventas:reader"
+allowedExtensions:
+  - "perfil_jefe"
+elements:
+  - "elemento_inventario_default"
+```
+
+| Campo | Requerido | Notas |
+|---|---|---|
+| `kind` | Sí | Siempre `JobTitle` |
+| `code` | Sí | Único por empresa, 3–50 caracteres, minúsculas/guiones bajos. **Inmutable tras la creación** |
+| `display` | Sí | Etiqueta legible (mutable) |
+| `isActive` | No | Por defecto `true` |
+| `accessRoles` | No | **Nombres** de AccessRole (sensibles a mayúsculas), máx. 50 |
+| `allowedExtensions` | No | **Códigos** de PropertyType, máx. 50 |
+| `elements` | No | **Códigos** de Property heredados por los usuarios |
+
+Los tres campos de lista referencian cada uno un recurso distinto por nombre o código:
+
+- **`accessRoles`** → nombres de rol que el usuario hereda.
+- **`allowedExtensions`** → *tipos* de propiedad que un usuario puede adjuntar como extensión de perfil.
+- **`elements`** → *propiedades* específicas (ej. una ubicación por defecto) que el usuario hereda.
+
+<div className="alert alert--primary">
+
+**Estas listas son REEMPLAZO al actualizar, no fusión.** Cuando actualizás un cargo, el array que enviás *reemplaza* el del servidor. Omití un rol que ya estaba, y se quita. Siempre exportá antes de una edición parcial:
+
+```bash
+cotctl jobtitles export store_manager -c acme -o store_manager.yaml
+```
+
+</div>
+
+<div className="alert alert--info">
+
+**Los nombres de rol son sensibles a mayúsculas.** `cotctl` matchea `accessRoles` exactamente. Si un nombre no se encuentra, el error incluye una sugerencia "¿quisiste decir…?" — normalmente un desliz de casing. Listá los nombres reales con `cotctl roles list -c <profile>`.
+
+</div>
+
+## Renombrar
+
+Como en varios recursos, `code` es inmutable, y no hay renombrado in situ para cargos. Para cambiar un código: desactivá el viejo, creá uno nuevo, y luego reapuntá a los usuarios afectados con `cotctl users apply` poniendo su `job` en el nuevo código.
+
+## Desactivación y reactivación
+
+Desactivá con el comando dedicado (o `isActive: false` en YAML):
+
+```bash
+cotctl jobtitles deactivate store_manager -c acme
+```
+
+Reactivar está deliberadamente protegido: aplicar `isActive: true` a un cargo actualmente inactivo requiere el flag explícito `--allow-reactivate`, así nunca traés uno de vuelta por accidente.
+
+## Aplicá los cargos antes que los usuarios
+
+<div className="alert alert--secondary">
+
+**El orden importa acá por una razón sutil.** Si aplicás un usuario cuyo `job` aún no existe como cargo, el backend puede crear silenciosamente un cargo placeholder — a menudo malformado o inactivo — que luego rompe applies posteriores de usuarios. Aplicar los cargos primero evita esto por completo, y `cotctl apply --dir` impone el orden por vos.
+
+</div>
+
+## Ver también
+
+- [Roles](./roles.md), [Tipos de propiedad](./properties.md) — lo que un cargo referencia
+- [Usuarios](./users.md) — referencian cargos vía `job`
+- [apply](../commands/apply.md) — los cargos se aplican cuarto, antes que los usuarios

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/properties.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/properties.md
@@ -1,0 +1,128 @@
+---
+title: Tipos de propiedad y propiedades (YAML)
+sidebar_label: Propiedades y tipos
+displayed_sidebar: developer
+---
+
+El modelo de datos de Cotalker se construye a partir de dos recursos relacionados: **tipos de propiedad** y **propiedades**. Entender la relación entre ellos es la clave de todo el modelo, así que empecemos por ahí.
+
+## El modelo mental: tipo vs. instancia
+
+Un **tipo de propiedad** es un *esquema* — define la forma de algo, como "una Ubicación tiene una dirección, una ciudad y un país." Una **propiedad** es una *instancia* de ese esquema — como "Santiago, en Av. Providencia 1234, en Chile."
+
+Si trabajaste con bases de datos, un tipo de propiedad es la definición de la tabla y una propiedad es una fila. Definís el tipo una vez, y luego creás tantas propiedades de ese tipo como necesites.
+
+Como las propiedades dependen de su tipo, el tipo debe existir primero — y `cotctl apply --dir` impone exactamente ese orden (tipos de propiedad antes que propiedades).
+
+## Tipos de propiedad
+
+Un tipo de propiedad declara un `code`, un nombre `display` y una lista de `schemaNodes` (sus campos):
+
+```yaml
+kind: PropertyType
+code: location
+display: Location
+hidden: true
+schemaNodes:
+  - key: address
+    display: Address
+    basicType: string
+    validators:
+      required: true
+  - key: city
+    display: City
+    basicType: string
+```
+
+| Campo | Requerido | Notas |
+|---|---|---|
+| `kind` | Sí | Siempre `PropertyType` |
+| `code` | Sí | Único por empresa. **Inmutable tras la creación** |
+| `display` | Sí | Nombre para mostrar en la UI |
+| `hidden` | No | Por defecto `true`. Ver abajo |
+| `viewPermissions` | Condicional | Nombres de AccessRole. **Requerido cuando `hidden: false`** |
+| `schemaNodes` | No | Las definiciones de campos |
+
+### Tipos visibles vs. ocultos
+
+La mayoría de los tipos de propiedad son maquinaria interna (estados de workflow, configuración) y deberían quedar en `hidden: true`. Poné `hidden: false` solo para tipos que los usuarios realmente navegan en la UI de la plataforma — catálogos de ubicaciones, equipos o empleados que aparecen en selectores de formularios. Cuando lo hagas, **debés** listar los roles que pueden navegarlos:
+
+```yaml
+hidden: false
+viewPermissions:
+  - Admin
+  - "Human Resources"   # los espacios están permitidos en los nombres de rol
+```
+
+<div className="alert alert--info">
+
+**No podés borrar un schema node vía YAML.** Si el servidor tiene campos que tu YAML no, `cotctl` los conserva — la omisión nunca es destructiva acá. Para retirar un nodo, poné `isActive: false` en él.
+
+</div>
+
+## Propiedades
+
+Una propiedad es una instancia. Nombra su tipo y completa el esquema con un `schemaInstance`:
+
+```yaml
+kind: Property
+code: santiago
+display: Santiago
+propertyType: location          # inmutable tras la creación
+schemaInstance:
+  address: Av. Providencia 1234
+  city: Santiago
+  country: Chile
+```
+
+| Campo | Requerido | Notas |
+|---|---|---|
+| `kind` | Sí | Siempre `Property` |
+| `code` | Sí | Único por empresa. Mín. 3 caracteres. **Inmutable** |
+| `display` | Sí | Nombre para mostrar (mutable) |
+| `propertyType` | Sí | El **code** del tipo. **Inmutable tras la creación** |
+| `schemaInstance` | No | Los datos, indexados por el `schemaNodes[].key` del tipo |
+
+Las claves dentro de `schemaInstance` deben coincidir con los campos `key` que definiste en el tipo de propiedad. Para ver qué claves son válidas:
+
+```bash
+cotctl property-types get location -c acme
+```
+
+### Jerarquías con `subproperty`
+
+Las propiedades pueden formar árboles padre-hijo vía `subproperty` (una lista de códigos de propiedades hijas) — útil para cosas como regiones que contienen ciudades:
+
+```yaml
+kind: Property
+code: region_sur
+display: Región Sur
+propertyType: location
+subproperty:
+  - santiago
+  - temuco
+```
+
+Las hijas deben existir antes que el padre — o aplicarse en el mismo archivo de batch.
+
+<div className="alert alert--primary">
+
+**Dos campos inmutables en una propiedad: `code` y `propertyType`.** Ninguno puede cambiar tras la creación. Para "mover" una propiedad a otro tipo, desactivá la vieja y creá una nueva con el tipo correcto — los datos no se migran automáticamente.
+
+</div>
+
+## Desactivar
+
+Preferí el comando dedicado:
+
+```bash
+cotctl properties deactivate santiago -c acme
+```
+
+Si una propiedad todavía está referenciada por un workflow o formulario activo, la desactivación se **bloquea** — resolvé la dependencia primero. Notá que desactivar un *tipo* de propiedad no desactiva sus propiedades; quedan activas pero huérfanas, así que desactivá en el orden correcto.
+
+## Ver también
+
+- [apply](../commands/apply.md) — el orden de apply pone tipos antes que propiedades
+- [Workflows](./workflows.md) — los estados de workflow son propiedades
+- [Cargos](./jobtitles.md) — referencian tipos de propiedad y propiedades

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/roles.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/roles.md
@@ -1,0 +1,98 @@
+---
+title: Roles de acceso (YAML)
+sidebar_label: Roles
+displayed_sidebar: developer
+---
+
+Un **rol de acceso** agrupa un conjunto de permisos bajo un nombre. Los roles son el fundamento del control de acceso en Cotalker — todo otro recurso que otorga acceso (workflows, tipos de propiedad, cargos, usuarios) se refiere a los roles por nombre. Por eso `cotctl apply --dir` aplica los roles *primero*: todo lo demás depende de ellos.
+
+## La forma de un rol
+
+Un rol es un `name`, una `description` opcional y una lista de `permissions`:
+
+```yaml
+kind: AccessRole
+name: "ordenes-compra:manager"
+description: "Manager role — full access to the OC flow"
+active: true
+permissions:
+  - ordenes-compra:start-form
+  - ordenes-compra:view
+  - ordenes-compra:view-all
+  - ordenes-compra:write
+```
+
+| Campo | Requerido | Notas |
+|---|---|---|
+| `kind` | Sí | Siempre `AccessRole` |
+| `name` | Sí | Único por empresa. **Sensible a mayúsculas** — es la clave de upsert |
+| `description` | No | Texto libre |
+| `active` | No | Por defecto `true`. **Notá que el campo es `active`, no `isActive`** |
+| `permissions` | Sí | Al menos un permiso |
+
+<div className="alert alert--secondary">
+
+**Dos errores fáciles de evitar.** Primero, el flag de activo acá es `active` — no `isActive` como en todos los demás recursos. Escribir `isActive` se ignora silenciosamente. Segundo, `name` es sensible a mayúsculas: `Admin` y `admin` son roles *distintos*, así que aplicar el casing equivocado crea un rol nuevo en vez de actualizar el que querías.
+
+</div>
+
+## Convenciones de nombres
+
+La convención de implementación de Cotalker es un rol por permiso, nombrado `{flow}:{action}`, más un rol "Manager" agregado que tiene el conjunto completo:
+
+```yaml
+# Componible, un permiso cada uno
+name: "ordenes-compra:start-form"
+name: "ordenes-compra:view"
+name: "ordenes-compra:view-all"
+name: "ordenes-compra:write"
+
+# Agregado
+name: "Órdenes de Compra: Manager"
+```
+
+Esta componibilidad es lo que te permite asignar exactamente el acceso correcto a cada cargo. `cotctl` imprime warnings no bloqueantes para nombres que se desvían de la convención `{flow}:{action}`.
+
+## Renombrar un rol
+
+Cambiar `name` crea un *nuevo* rol — no renombra el existente. Para renombrar in situ manteniendo todas las referencias intactas, fijá el rol por su `id`:
+
+```bash
+cotctl roles export "Old Name" -c acme -o role.yaml
+```
+
+Luego descomentá la línea `id` en el archivo exportado, cambiá `name`, y aplicá. (Los permisos del rol pueden editarse al mismo tiempo.)
+
+## Desactivar
+
+Ya sea con el comando dedicado:
+
+```bash
+cotctl roles deactivate "old-role:viewer" -c acme
+```
+
+…o declarativamente con `active: false` en el YAML, lo que es práctico en setups versionados y por batch.
+
+## Aplicar varios a la vez
+
+Un único archivo puede contener muchos roles, separados por `---` — este es el patrón común para el conjunto entero de permisos de un workflow:
+
+```yaml
+kind: AccessRole
+name: "ordenes-compra:manager"
+permissions:
+  - ordenes-compra:view
+  - ordenes-compra:write
+---
+kind: AccessRole
+name: "ordenes-compra:solicitante"
+permissions:
+  - ordenes-compra:start-form
+  - ordenes-compra:view
+```
+
+## Ver también
+
+- [apply](../commands/apply.md) — los roles se aplican primero
+- [Cargos](./jobtitles.md) y [Workflows](./workflows.md) — ambos referencian roles por nombre
+- Usá `cotctl roles list -c <profile>` para ver los nombres de rol existentes y su casing exacto

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/surveys.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/surveys.md
@@ -1,0 +1,121 @@
+---
+title: Encuestas (YAML)
+sidebar_label: Encuestas
+displayed_sidebar: developer
+---
+
+Una **encuesta** es un formulario — la forma en que Cotalker captura datos estructurados de las personas. Las encuestas suelen ser el primer recurso que los partners aprenden a gestionar con `cotctl`, porque son autocontenidas e inmediatamente útiles. Esta página explica la estructura YAML para que puedas crearlas y versionarlas con confianza.
+
+## La forma de una encuesta
+
+En su forma más simple, una encuesta es un `code`, un `name` y una lista de `questions`:
+
+```yaml
+kind: Survey
+code: registro_empleado
+name: "Employee Registration"
+questions:
+  - type: textinput
+    identifier: re_nombre
+    label: "Name"
+```
+
+### Campos raíz
+
+| Campo | Requerido | Descripción |
+|---|---|---|
+| `kind` | Sí | Siempre `Survey` |
+| `code` | Sí | Único por empresa. Minúsculas, números, guiones bajos. **Inmutable tras la creación** |
+| `name` | Sí | Nombre para mostrar |
+| `isActive` | No | Por defecto `true` |
+
+<div className="alert alert--primary">
+
+**`code` es inmutable.** Una vez creada una encuesta, su `code` no puede cambiar — elegilo con cuidado. Lo mismo aplica al `identifier` de cada pregunta. Para "renombrar" cualquiera de los dos, creás un recurso nuevo. Por eso recomendamos una convención de nombres clara desde el principio.
+
+</div>
+
+Más allá de estos, las encuestas soportan muchos campos opcionales para quién puede responder, edición post-envío, visibilidad condicional, scoring, y vincular respuestas a campos de tareas. Recurrirás a esos según lo pidan los proyectos; esta página se enfoca en la estructura que usarás todos los días.
+
+## Preguntas
+
+`questions` es un array, y toda pregunta comparte un conjunto común de campos sin importar su tipo:
+
+| Campo | Requerido | Descripción |
+|---|---|---|
+| `type` | Sí | El tipo de pregunta (ver abajo) |
+| `identifier` | Sí | ID único a nivel de empresa |
+| `label` | Sí | La etiqueta visible |
+| `help` | No | Texto de ayuda secundario |
+| `required` | No | Por defecto `false` |
+| `isReadOnly` | No | Por defecto `false` |
+
+### Identificadores: la regla a internalizar
+
+El `identifier` de una pregunta debe ser **único en toda la empresa**, no solo dentro de esta encuesta. La convención que te mantiene fuera de problemas es **prefijar cada identifier con el código de la encuesta**:
+
+```yaml
+# BIEN — prefijado, no colisiona
+identifier: re_nombre
+
+# MAL — genérico, colisionará con otras encuestas
+identifier: nombre
+```
+
+Algunas palabras están reservadas y no pueden usarse como identifiers: `survey`, `user`, `channel`, `_id`, `UUID`, `target`, `properties`.
+
+### Tipos de pregunta
+
+Cotalker ofrece un conjunto rico de tipos de pregunta. Acá está el catálogo — elegí el que coincida con el dato que estás capturando:
+
+| Tipo | Para |
+|---|---|
+| `text` | Texto estático, títulos, separadores |
+| `textinput` | Texto libre |
+| `textnumber` | Números, enteros, ratings |
+| `listquestion` | Selección única/múltiple (radio/checkbox) |
+| `property` | Seleccionar desde una propiedad del modelo de datos |
+| `person` | Seleccionar una persona |
+| `api` | Seleccionar desde una API externa |
+| `datetime` | Fecha y hora |
+| `gps` | Una ubicación |
+| `image` | Una foto o imagen |
+| `file` | Un archivo adjunto |
+| `signature` | Una firma digital |
+| `survey` | Una subencuesta embebida |
+
+Un par de tipos tienen subcampos requeridos que conviene recordar: `listquestion` necesita una lista `options` no vacía, y `property` necesita un bloque `filters`:
+
+```yaml
+- type: listquestion
+  identifier: re_cargo
+  label: "Role"
+  options:
+    - label: "Analyst"
+      value: "analista"
+
+- type: property
+  identifier: re_area
+  label: "Area"
+  filters:
+    - propertyType: "area"
+      subfilter: "*"
+```
+
+## Editar encuestas con seguridad
+
+Como [`apply`](../commands/apply.md) matchea las preguntas por `identifier` en vez de por posición, podés agregar, editar, quitar y reordenar preguntas libremente — los IDs se preservan. Quitar una pregunta la desactiva (no se borra definitivamente), y se te pedirá confirmar. Si aplicás un YAML de encuesta sin su sección `questions`, las preguntas existentes quedan intactas.
+
+## Un consejo práctico
+
+La forma más rápida de aprender la estructura completa es exportar una encuesta real y leerla:
+
+```bash
+cotctl surveys export <some_survey> -c acme -o example.yaml
+```
+
+## Ver también
+
+- [apply](../commands/apply.md) — cómo se crean y actualizan las encuestas
+- [Exportar e importar](../commands/export-import.md) — las opciones de exportación, incluyendo `--extract-scripts`
+- [Workflows](./workflows.md) — las encuestas son referenciadas por las transiciones de workflow

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/users.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/users.md
@@ -1,0 +1,101 @@
+---
+title: Usuarios (YAML)
+sidebar_label: Usuarios
+displayed_sidebar: developer
+---
+
+Un **usuario** es una persona en una empresa. Los usuarios son el recurso más conectado de Cotalker — cada uno referencia un [cargo](./jobtitles.md), uno o más [roles de acceso](./roles.md), y puede ubicarse en una jerarquía de organigrama con otros usuarios. Por esas dependencias, los usuarios se aplican **al final** (después de que existan los cargos y roles).
+
+## La forma de un usuario
+
+```yaml
+kind: User
+email: juan.perez@acme.com
+name:
+  names: Juan
+  lastName: Pérez
+job: store_manager               # código de JobTitle — debe estar activo
+accessRoles:
+  - "ordenes-compra:manager"     # nombres de AccessRole — sensibles a mayúsculas
+phone: "+56912345678"
+isActive: true
+```
+
+| Campo | Requerido | Notas |
+|---|---|---|
+| `kind` | Sí | Siempre `User` |
+| `email` | Sí | La clave de upsert. Único globalmente, auto-minúsculas. **Inmutable tras la creación** |
+| `name` | Sí | Sub-objeto: `names` (requerido), `lastName`, `secondLastName` |
+| `job` | Sí | Un **code** de JobTitle que exista y esté **activo** |
+| `accessRoles` | No | **Nombres** de AccessRole (sensibles a mayúsculas) |
+| `phone`, `isActive`, `settings` | No | Campos de perfil opcionales |
+
+El campo `name` es un objeto, no un string. `cotctl` construye el nombre para mostrar a partir de él automáticamente:
+
+```yaml
+name:
+  names: Juan
+  lastName: Pérez
+  secondLastName: García
+```
+
+## Cargo y roles
+
+`job` apunta a un cargo por **code**, y ese cargo debe estar activo — `cotctl` solo resuelve los activos. `accessRoles` lista **nombres** de rol, y como en todas partes, son sensibles a mayúsculas (`Manager` ≠ `manager`).
+
+<div className="alert alert--info">
+
+**El rol por defecto.** Si creás un usuario sin `accessRoles`, el backend le asigna un rol `default` automáticamente. Lo vas a ver aparecer en exportaciones posteriores — eso es esperado, no un bug.
+
+</div>
+
+## Jerarquía
+
+Podés ubicar a un usuario en el organigrama con `hierarchy`. Las tres listas contienen **emails**, resueltos en el momento del apply:
+
+```yaml
+hierarchy:
+  boss:
+    - manager@acme.com
+  peers:
+    - colleague@acme.com
+  subordinate:          # ¡singular!
+    - junior1@acme.com
+    - junior2@acme.com
+```
+
+<div className="alert alert--primary">
+
+**`subordinate` es singular.** La clave es `subordinate`, no `subordinates`. Como el esquema de usuario es permisivo, escribir el plural *no produce error* — el usuario se aplica sin subordinados, silenciosamente. Verificá dos veces esta clave cada vez que construyas una jerarquía.
+
+</div>
+
+Cuando aplicás un batch de usuarios que se referencian entre sí (el jefe de A es B, ambos nuevos), `cotctl` lo maneja con un apply de dos pasadas, así las referencias hacia adelante resuelven correctamente.
+
+## Metadata personalizada: `extra`
+
+`extra` es un mapa clave-valor libre para cualquier otra cosa que necesites guardar:
+
+```yaml
+extra:
+  department: "Sales"
+  rut: "12.345.678-9"
+```
+
+Al actualizar, `extra` se **fusiona** — las claves que proveés ganan, las que ya están en el servidor se conservan. No podés borrar una clave de `extra` a través del YAML.
+
+<div className="alert alert--secondary">
+
+**`extra` suele contener PII** (documentos de identidad, etc.), y aparece tal cual en las exportaciones. Revisá este campo antes de commitear un YAML de usuario exportado al control de versiones.
+
+</div>
+
+## Una nota sobre contraseñas
+
+`password` es de solo escritura — podés establecerla en el apply, pero nunca se exporta. Para flujos de onboarding y los detalles de cómo se comportan las contraseñas y la reactivación, mirá la referencia de comandos.
+
+## Ver también
+
+- [Cargos](./jobtitles.md) — el `job` que un usuario referencia (aplicá estos primero)
+- [Roles](./roles.md) — los `accessRoles` que un usuario referencia
+- [apply](../commands/apply.md) — los usuarios se aplican al final

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/workflows.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/resources/workflows.md
@@ -1,0 +1,138 @@
+---
+title: Workflows (YAML)
+sidebar_label: Workflows
+displayed_sidebar: developer
+---
+
+Un **workflow** modela un proceso: una tarea que se mueve a través de una serie de estados, desde la creación hasta el cierre. Los workflows son el recurso más potente — y el más estructurado — de Cotalker. La buena noticia es que rara vez escribís uno desde cero: [`cotctl workflows scaffold`](../commands/scaffolding.md) genera un esqueleto correcto, y esta página explica qué contiene ese esqueleto para que lo personalices con confianza.
+
+## La jerarquía
+
+Un único documento YAML de workflow gestiona una estructura anidada:
+
+```
+Workflow                 (el proceso: nombre, permisos, settings)
+└── stateMachines[]      (uno o más flujos independientes)
+    └── states[]         (los pasos por los que pasa una tarea)
+        └── next[]       (las transiciones permitidas entre estados)
+```
+
+## El nivel del workflow
+
+La parte superior del archivo describe el workflow en sí:
+
+```yaml
+kind: Workflow
+nameCode: purchase_orders        # inmutable tras la creación
+nameDisplay: Purchase Orders
+isActive: true
+hideClosedAfterDays: 30
+readPermissions:
+  - Admin                        # nombres de AccessRole
+writePermissions:
+  - Admin
+  - Manager
+stateMachines:
+  - # ...
+```
+
+| Campo | Requerido | Notas |
+|---|---|---|
+| `kind` | Sí | Siempre `Workflow` |
+| `nameCode` | Sí | Único por empresa. **Inmutable tras la creación.** Mín. 3 caracteres, minúsculas/guiones bajos |
+| `nameDisplay` | No | Nombre para mostrar. Si se omite, apply corre en "modo SM-only" (ver abajo) |
+| `isActive` | No | Por defecto `true` |
+| `hideClosedAfterDays` | No | Días antes de ocultar tareas cerradas. **Por defecto 7, que suele ser demasiado corto** — considerá 30 |
+| `readPermissions` / `writePermissions` | No | **Nombres** de AccessRole — quién puede leer / crear tareas |
+
+<div className="alert alert--secondary">
+
+**Los permisos se matchean por nombre, y los typos fallan en silencio.** Las listas de permisos usan *nombres* de AccessRole, que `cotctl` resuelve a IDs en el apply. Si un nombre no existe en el servidor, se **descarta silenciosamente** — sin error. Después de aplicar, verificá con `cotctl workflows get <nameCode>` que cada permiso haya quedado.
+
+</div>
+
+## Máquinas de estado
+
+Cada entrada en `stateMachines[]` es un flujo independiente. Declara qué datos la mueven y dónde arranca:
+
+```yaml
+stateMachines:
+  - code: sm_po_main
+    name: PO Main Flow
+    propertyType: pt_po_states     # inmutable tras la creación
+    asset:
+      type: unique                 # "unique" o "generic" — inmutable
+      propertyType: pt_po_assets
+    initialState: po_draft         # un código de propiedad de estado
+    states:
+      - # ...
+```
+
+El `propertyType` y el `asset.type` son **inmutables tras la creación** — definen la forma fundamental del flujo, así que planificalos de antemano.
+
+## Estados y transiciones
+
+Cada estado corresponde a una [Property](./properties.md) y declara su tipo de ciclo de vida y sus transiciones salientes:
+
+```yaml
+states:
+  - property: po_draft        # un código de Property que ya debe existir
+    type: new                 # "new" | "in-progress" | "closed" — inmutable
+    next:
+      - target: po_approved
+        canChange: manual
+      - target: po_rejected
+        canChange: survey
+        requiredSurvey: survey_rejection_reason
+```
+
+El `canChange` de una transición controla cómo se dispara:
+
+| `canChange` | Significado |
+|---|---|
+| `manual` (default) | Un usuario la dispara desde la UI de la tarea |
+| `survey` | El usuario debe completar una encuesta primero — poné `requiredSurvey` con su código |
+| `none` | Solo la automatización/el sistema puede dispararla (ej. auto-cierre) |
+
+<div className="alert alert--primary">
+
+**Los estados son permanentes.** Una vez creado, un estado no puede borrarse ni desactivarse, y su `type` no puede cambiar. Quitar un estado de tu YAML no lo borra — el apply bloqueará el cambio. Diseñá tu conjunto de estados deliberadamente.
+
+</div>
+
+## Automatización: bots
+
+Las transiciones y los estados pueden disparar **bots** — pequeñas rutinas de automatización que corren cuando una transición se dispara o se envía un formulario (enviar una notificación, crear una tarea de seguimiento, llamar a una API). Los bots son un tema avanzado, con su propio catálogo de tipos; por ahora, lo que importa es una regla de seguridad:
+
+<div className="alert alert--secondary">
+
+**Las tres formas de un campo `bots` — y por qué importa.** Cuando escribís un slot `bots` en YAML, la forma que elegís cambia el comportamiento:
+
+| YAML | Efecto en el apply |
+|---|---|
+| Campo **ausente** | **Preservar** los bots que el servidor ya tiene en ese slot |
+| `bots: []` | **Borrar** los bots de ese slot (destructivo) |
+| `bots: [{...}]` | **Reemplazar** por el bot que declaraste |
+
+Si los bots se configuraron fuera de `cotctl` (por ejemplo, en el builder web), un `bots: []` accidental los borrará. Ante la duda, hacé `cotctl workflows export` primero para ver qué hay.
+
+</div>
+
+## Modo SM-only
+
+Si omitís `nameDisplay`, el apply corre en **modo SM-only**: toca solo las máquinas de estado y los estados, dejando intactos los settings de display y los permisos del workflow. Es justo lo que querés al agregar una segunda máquina de estado a un workflow que ya existe, sin resetear nada.
+
+## Una nota de dependencias
+
+El `requiredSurvey` de una transición referencia una encuesta por código. Por el orden de apply, cuando usás `apply --dir`, los workflows se aplican *antes* que las encuestas. Si una transición necesita una encuesta, aplicá las encuestas primero, luego el workflow:
+
+```bash
+cotctl surveys apply -f surveys.yaml -c acme
+cotctl workflows apply -f workflow.yaml -c acme
+```
+
+## Ver también
+
+- [Scaffolding](../commands/scaffolding.md) — generá el esqueleto del workflow
+- [Propiedades](./properties.md) y [Roles](./roles.md) — los recursos que un workflow referencia
+- [validate](../commands/validate.md) — el checklist de preparación para producción de workflows en vivo

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/skills.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/skills.md
@@ -1,0 +1,88 @@
+---
+title: Skills para Claude Code
+sidebar_label: Skills
+displayed_sidebar: developer
+---
+
+Un **Skill** es un paquete instalable que le da al agente de IA Claude Code conocimiento y herramientas especializadas para un área específica. `cotctl` trae un conjunto de Skills — uno por tipo de recurso — que convierten a un agente de propósito general en un especialista en authoring de Cotalker. Esta página es la referencia del comando `cotctl skills` que los gestiona. Para el panorama de cómo encajan los Skills con el RAG y el agente, mirá [Authoring asistido por IA](./ai-authoring.md).
+
+## Listar lo disponible
+
+```bash
+cotctl skills list
+```
+
+Esto muestra cada Skill disponible y su estado de instalación, que puede ser `[not installed]`, `[local]`, `[global]` o `[local, global]`.
+
+## Instalar Skills
+
+```bash
+cotctl skills install [name] [options]
+```
+
+Ejecutalo **sin un nombre** para obtener un checklist interactivo y elegir lo que quieras. Pasá un nombre para instalar uno específico.
+
+| Opción | Descripción |
+|---|---|
+| `--all` | Instala todos los Skills disponibles |
+| `--local` | Instala en `.claude/skills/` (solo este proyecto) |
+| `--global` | Instala en `~/.claude/skills/` (todos los proyectos) |
+| `--no-mcp` | Salta el paso de configuración del RAG/MCP de Cotalker |
+
+Si no pasás `--local` ni `--global`, `cotctl` te pregunta interactivamente qué scope usar.
+
+<div className="alert alert--info">
+
+**Instalar también ofrece conectar el RAG.** Después de instalar, `cotctl` ofrece configurar la conexión MCP al servicio de documentación de Cotalker — la mitad de "grounding en vivo" del setup. Salteala con `--no-mcp`, o configurala más tarde con [`cotctl mcp install`](./mcp-integration.md). Para la mayoría de los partners, aceptarla es lo correcto.
+
+</div>
+
+## Los Skills disponibles
+
+Cada Skill especializa al agente en un área de recursos:
+
+| Skill | Qué le da al agente |
+|---|---|
+| `cotctl-surveys` | Crear y modificar YAML de encuestas |
+| `cotctl-workflows` | Crear, scaffoldear y modificar workflows |
+| `cotctl-properties` | Generar tipos de propiedad y propiedades |
+| `cotctl-roles` | Crear y gestionar roles de acceso y permisos |
+| `cotctl-apply` | Aplicar recursos a entornos de Cotalker |
+| `cotctl-export` | Exportar y consultar recursos |
+| `cotalker-docs` | Conocimiento general de la plataforma Cotalker |
+
+Un punto de partida común es instalarlos todos:
+
+```bash
+cotctl skills install --all --local
+```
+
+## Scopes: local vs. global
+
+Dónde se instala un Skill determina qué proyectos pueden usarlo:
+
+| Scope | Directorio | Aplica a |
+|---|---|---|
+| Local | `.claude/skills/` | Solo el proyecto actual |
+| Global | `~/.claude/skills/` | Todos tus proyectos |
+
+Usá **local** cuando trabajás en el repositorio de un cliente específico y querés los Skills versionados junto a él; usá **global** cuando querés tenerlos disponibles en todos lados donde trabajás.
+
+## Desinstalar
+
+```bash
+cotctl skills uninstall [name] [options]
+```
+
+| Opción | Descripción |
+|---|---|
+| `--all` | Desinstala todos los Skills del scope seleccionado |
+| `--local` | Desinstala del proyecto actual |
+| `--global` | Desinstala de la configuración global |
+
+Cuando desinstalás con `--all`, `cotctl` también pregunta si querés quitar la configuración del RAG/MCP que se configuró junto a los Skills.
+
+## Ver también
+
+- [Authoring asistido por IA](./ai-authoring.md) — cómo trabajan juntos los Skills, el RAG y el agente
+- [Integración MCP](./mcp-integration.md) — el RAG de documentación que los Skills ofrecen conectar

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/troubleshooting.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/troubleshooting.md
@@ -1,0 +1,83 @@
+---
+title: Solución de problemas
+sidebar_label: Solución de problemas
+displayed_sidebar: developer
+---
+
+La mayoría de los errores de `cotctl` son claros y te dicen cómo resolverlos. Esta página reúne los que más probablemente vas a encontrar, organizados como **síntoma → causa → solución** para que encuentres el tuyo rápido.
+
+## Instalación y setup
+
+### `cotctl: command not found` después de un install global
+
+- **Causa:** el directorio de binarios globales de npm no está en tu `PATH`.
+- **Solución:** confirmá dónde instala npm los binarios globales con `npm bin -g`, y agregá ese directorio a tu `PATH`. Como atajo, siempre podés ejecutar la herramienta vía `npx @cotctl/cli <command>`.
+
+## Autenticación y perfiles
+
+### `--company/-c is required`
+
+- **Causa:** el comando necesita un perfil y no pasaste ninguno. No hay default, por diseño.
+- **Solución:** agregá `-c <profile>`. Ejecutá `cotctl profile list` para ver los nombres disponibles.
+
+### `Profile '<name>' not found`
+
+- **Causa:** ese perfil no existe localmente (typo, o nunca te logueaste a él).
+- **Solución:** revisá `cotctl profile list`; ejecutá `cotctl login` si falta.
+
+### `Session expired for profile "<name>"` / `Failed to refresh token`
+
+- **Causa:** el token tiene más de 7 días, o fue revocado del lado del servidor.
+- **Solución:** ejecutá `cotctl login` de nuevo para ese entorno.
+
+### `API Error 401`
+
+- **Causa:** el token es inválido.
+- **Solución:** reautenticate con `cotctl login`.
+
+### `API Error 403`
+
+- **Causa:** el usuario logueado no tiene los permisos de administración requeridos.
+- **Solución:** esto es un tema de permisos de Cotalker — pedile al administrador de la empresa que le otorgue al usuario los permisos necesarios, y reintentá.
+
+### `Could not discover API URL from <url>`
+
+- **Causa:** la URL del webclient es incorrecta, o (común on-premise) el webclient no sirve el archivo de variables que `cotctl` lee para encontrar la API.
+- **Solución:** revisá el `--url`. On-premise, pasá la API explícitamente con `--api-url https://api.empresa.com`.
+
+### `Token does not belong to the specified company`
+
+- **Causa:** el token fue emitido para una empresa distinta del subdominio/URL que especificaste.
+- **Solución:** verificá que el `--subdomain` y la `--url` coincidan con el entorno que querés.
+
+## YAML y validación
+
+### `YAML parse error`
+
+- **Causa:** sintaxis YAML inválida — normalmente indentación o un carácter perdido.
+- **Solución:** revisá la indentación (espacios, no tabs) y el formato. Ejecutar `cotctl validate -f <file>` apunta a la línea problemática.
+
+### Conflicto de identificador en validación remota / `Duplicate key error`
+
+- **Causa:** un `identifier` de pregunta ya existe en otra encuesta de la empresa — los identificadores son únicos a nivel de empresa, no por encuesta.
+- **Solución:** renombrá el identifier, prefijándolo con el código de la encuesta (ej. `re_nombre` en vez de `nombre`).
+
+### Un exec hook no corre, o `Illegal return statement`
+
+- **Causa:** al `src` del script le falta su envoltura `function run()`, así que un `return` de nivel superior es inválido.
+- **Solución:** envolvé la lógica en `function run() { ... }` (o `async function run()`).
+
+## Encuestas: preguntas huérfanas
+
+Esta vale la pena entenderla porque es fácil de evitar y molesta de deshacer.
+
+- **Síntoma:** después de aplicar una encuesta con `questions: []`, ya no podés re-crear preguntas con los mismos identificadores.
+- **Causa:** aplicar un array de preguntas *vacío* deja las preguntas viejas atrás como registros huérfanos, y sus identificadores (únicos por empresa) ahora bloquean la re-creación.
+- **Solución / prevención:** nunca apliques `questions: []` para "limpiar" una encuesta. Para desactivar una encuesta, poné `isActive: false` *sin* tocar la sección de preguntas — `cotctl` preserva las preguntas existentes automáticamente cuando la sección está ausente. (Recuperarse de un huérfano existente requiere limpieza en el backend, así que acá la jugada es la prevención.)
+
+## ¿Todavía atascado?
+
+- Re-ejecutá el comando — muchos errores incluyen una pista precisa sobre la solución.
+- Para dudas de esquema, exportá un ejemplo funcionando del mismo recurso y compará:
+  `cotctl <entity> export <code> -c <profile> -o example.yaml`
+- Mirá la [referencia de comandos](./commands/apply.md) para las opciones y el comportamiento exacto de cada comando.

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/tutorials.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/tutorials.md
@@ -1,0 +1,119 @@
+---
+title: Tutoriales
+sidebar_label: Tutoriales
+displayed_sidebar: developer
+---
+
+Las páginas de referencia te dicen *qué* hace cada comando. Esta página te muestra *cómo* se combinan, con recetas completas para seguir paso a paso sobre las cosas que realmente vas a hacer en un proyecto. Cada receta lista qué necesitás antes de empezar y cómo se ve el éxito, para que sepas cuándo funcionó.
+
+Si todavía no instalaste y te autenticaste, arrancá por [Instalación](./installation.md) y [Autenticación](./authentication.md) — todas las recetas de abajo asumen que tenés un perfil funcionando.
+
+## Receta 1 — Iniciar sesión y confirmar tu setup
+
+**Qué necesitás:** `cotctl` instalado, y acceso de administrador a un entorno.
+
+```bash
+# Login (flujo de navegador por defecto)
+cotctl login --url https://web.cotalker.com --subdomain acme
+
+# Confirmar que el perfil se guardó
+cotctl profile list
+```
+
+**Cómo se ve el éxito:** `cotctl profile list` muestra una fila `acme` con tu URL y usuario. Estás listo para ejecutar cualquier comando con `-c acme`.
+
+## Receta 2 — Crear una encuesta nueva desde cero
+
+**Qué necesitás:** un perfil funcionando, y una idea del formulario que querés construir.
+
+```bash
+# 1. Escribí el YAML (ver la referencia de Encuestas para la estructura)
+vim my-survey.yaml
+
+# 2. Validalo offline — detectá errores antes de tocar el entorno
+cotctl validate -f my-survey.yaml
+
+# 3. Previsualizá lo que se enviaría, sin cambiar nada
+cotctl apply -f my-survey.yaml -c acme --dry-run
+
+# 4. Aplicá de verdad
+cotctl apply -f my-survey.yaml -c acme
+```
+
+**Cómo se ve el éxito:**
+
+```
+Survey "my_survey" created successfully (id: 507f1f77bcf86cd799439011)
+```
+
+<div className="alert alert--info">
+
+Esta secuencia validate → dry-run → apply es el default seguro para *todo* recurso, no solo encuestas. Construí el hábito ahora.
+
+</div>
+
+## Receta 3 — Modificar una encuesta existente
+
+**Qué necesitás:** el `code` de una encuesta que ya existe.
+
+```bash
+# 1. Exportala como punto de partida
+cotctl surveys export existing_survey -c acme -o survey.yaml
+
+# 2. Editá el YAML
+vim survey.yaml
+
+# 3. Validá, luego aplicá — se actualiza automáticamente porque el code existe
+cotctl validate -f survey.yaml
+cotctl apply -f survey.yaml -c acme
+```
+
+**Cómo se ve el éxito:** `Survey "existing_survey" updated successfully`. Podés agregar, quitar, editar y reordenar preguntas libremente — `cotctl` las matchea por `identifier` y preserva sus IDs.
+
+## Receta 4 — Promover una encuesta entre entornos
+
+**Qué necesitás:** perfiles para el entorno origen y el destino.
+
+```bash
+# 1. Exportar del origen
+cotctl surveys export my_survey -c acme-prod -o survey.yaml
+
+# 2. Aplicar al destino
+cotctl apply -f survey.yaml -c devteam
+```
+
+**Cómo se ve el éxito:** la encuesta se crea en el entorno destino. El YAML exportado contiene IDs del origen, pero se ignoran al crear — el destino genera los suyos.
+
+## Receta 5 — Construir y desplegar un workflow desde un scaffold
+
+Esta es la grande — el ciclo completo desde la nada hasta un workflow en vivo.
+
+**Qué necesitás:** un perfil funcionando y un nombre + código corto para tu flujo.
+
+```bash
+# 1. Generar el esqueleto
+cotctl workflows scaffold --name ordenes-compra --code oc \
+  --display "Órdenes de Compra"
+
+# 2. Personalizar los archivos generados:
+#    - estados en data-model/states.yaml
+#    - transiciones en workflow.yaml
+#    - roles/permisos en access/
+
+# 3. Validar la carpeta entera offline
+cotctl validate --dir ordenes-compra/
+
+# 4. Aplicar — las entidades se despliegan en el orden de dependencias correcto, automáticamente
+cotctl apply --dir ordenes-compra/ -c dev
+
+# 5. Correr el checklist de preparación para producción contra el workflow en vivo
+cotctl validate --workflow ordenes_compra -c dev
+```
+
+**Cómo se ve el éxito:** el paso 4 reporta `N created, 0 errors`, y el paso 5 termina con `production ready`. Los pasos 2–5 forman un ciclo que podés repetir con seguridad — cada apply es idempotente.
+
+## A dónde ir después
+
+- [Referencia YAML de recursos](./resources/surveys.md) — el esquema detrás de cada archivo que editás
+- [Solución de problemas](./troubleshooting.md) — cuando una receta no sale según el plan
+- [CI/CD](./ci-cd.md) — corré estos flujos automáticamente en cada merge

--- a/sidebars.js
+++ b/sidebars.js
@@ -326,6 +326,52 @@ module.exports = {
     },
     {
       type: 'category',
+      label: 'CLI (cotctl)',
+      link: {
+        type: 'doc',
+        id: 'developer/cli/overview',
+      },
+      collapsed: true,
+      items: [
+        'developer/cli/installation',
+        'developer/cli/authentication',
+        'developer/cli/demo-company',
+        {
+          type: 'category',
+          label: 'Commands',
+          collapsed: true,
+          items: [
+            'developer/cli/commands/login-logout',
+            'developer/cli/commands/profiles',
+            'developer/cli/commands/validate',
+            'developer/cli/commands/apply',
+            'developer/cli/commands/export-import',
+            'developer/cli/commands/scaffolding',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Resource YAML reference',
+          collapsed: true,
+          items: [
+            'developer/cli/resources/surveys',
+            'developer/cli/resources/workflows',
+            'developer/cli/resources/properties',
+            'developer/cli/resources/roles',
+            'developer/cli/resources/users',
+            'developer/cli/resources/jobtitles',
+          ],
+        },
+        'developer/cli/tutorials',
+        'developer/cli/troubleshooting',
+        'developer/cli/ci-cd',
+        'developer/cli/ai-authoring',
+        'developer/cli/skills',
+        'developer/cli/mcp-integration',
+      ],
+    },
+    {
+      type: 'category',
       label: 'API Reference',
       link: {
         type: 'doc',


### PR DESCRIPTION
## Qué es

Nueva sección **CLI (cotctl)** bajo el sidebar **Developer** de `doc.cotalker.com`, escrita para **partners de implementación** en registro guiado/tutorial. Hoy no existía documentación de la CLI para partners — esto la crea desde cero.

## Contenido — 22 páginas (EN + ES)

- **Onboarding:** overview · installation · authentication · **demo company** (practicá en una compañía no productiva primero — vía Partner Platform)
- **Comandos:** login/logout · profile · validate · apply · export/import · scaffolding
- **Referencia YAML de recursos:** surveys · workflows · properties · roles · users · job titles
- **Operación:** tutorials · troubleshooting · ci-cd
- **Ecosistema IA:** ai-authoring (agente + Skills + RAG) · skills · mcp-integration

## Notas

- Groundeado en `cotctl/docs`; se excluyó contenido interno (tokens hardcodeados, URLs de staging, internals de bots).
- Traducciones ES en `i18n/es/...`, listas para cuando se active la locale `es` (hoy comentada en `docusaurus.config.js`).
- **Build EN de producción verificado en verde** (sin links rotos).
- Pendiente de validación: implementator-agent → Leo → ops → partners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)