### PR TITLE
docs(cli): clarify managed MCP path needs no endpoint (O-3)

### DIFF
--- a/docs/developer/cli/mcp-integration.md
+++ b/docs/developer/cli/mcp-integration.md
@@ -22,7 +22,7 @@ cotctl mcp install
 
 <div className="alert alert--info">
 
-**Where's the endpoint?** The MCP endpoint URL is specific to your Cotalker environment — your Cotalker contact can provide it. `cotctl mcp install` handles the connection details for you, so the managed command is the recommended route.
+**The managed path needs no endpoint.** `cotctl mcp install` already knows the default Cotalker documentation endpoint, so you don't have to supply one — just run it. You only need an explicit URL if you register the server manually with `claude mcp add` (below), or want to point at a non-default environment (override it with the `COTCTL_MCP_URL` environment variable).
 
 </div>
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/mcp-integration.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/mcp-integration.md
@@ -22,7 +22,7 @@ cotctl mcp install
 
 <div className="alert alert--info">
 
-**¿Dónde está el endpoint?** La URL del endpoint MCP es específica de tu entorno de Cotalker — tu contacto de Cotalker te la puede proveer. `cotctl mcp install` maneja los detalles de conexión por vos, así que el comando gestionado es la ruta recomendada.
+**La vía gestionada no necesita endpoint.** `cotctl mcp install` ya conoce el endpoint de documentación de Cotalker por defecto, así que no tienes que indicarlo — solo ejecútalo. Solo necesitas una URL explícita si registras el servidor manualmente con `claude mcp add` (abajo), o si quieres apuntar a un entorno distinto del default (puedes sobrescribirlo con la variable de entorno `COTCTL_MCP_URL`).
 
 </div>
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/mcp-integration.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer/cli/mcp-integration.md
@@ -22,7 +22,7 @@ cotctl mcp install
 
 <div className="alert alert--info">
 
-**La vía gestionada no necesita endpoint.** `cotctl mcp install` ya conoce el endpoint de documentación de Cotalker por defecto, así que no tienes que indicarlo — solo ejecútalo. Solo necesitas una URL explícita si registras el servidor manualmente con `claude mcp add` (abajo), o si quieres apuntar a un entorno distinto del default (puedes sobrescribirlo con la variable de entorno `COTCTL_MCP_URL`).
+**La vía gestionada no necesita endpoint.** `cotctl mcp install` ya conoce el endpoint de documentación de Cotalker por defecto, así que no tienes que indicarlo — solo ejecútalo. Solo necesitas una URL explícita si registras el servidor manualmente con `claude mcp add` (abajo), o si quieres apuntar a un entorno distinto del predeterminado (puedes sobrescribirlo con la variable de entorno `COTCTL_MCP_URL`).
 
 </div>
 


### PR DESCRIPTION
Follow-up de la review de Leo (O-3): aclara que `cotctl mcp install` ya trae el endpoint por defecto (`llm.cotalker.com`), así que el partner no necesita indicarlo; solo la vía manual `claude mcp add` requiere URL. EN + ES (tuteo).

Aparte — **O-2 (binario standalone): no lo documenté a propósito.** Los binarios del último GitHub Release son `release-0.6.1` pero npm va en `0.8.0` → documentar el binario mandaría a partners a una versión vieja. Es un gap del pipeline de releases de cotctl, no del doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)