### PR TITLE
fix(seo): trailing slash canónico, robots.txt y redirects del locale /es/ eliminado

### DIFF
--- a/docs/certification/basic_admin/certification_admin_ws2.md
+++ b/docs/certification/basic_admin/certification_admin_ws2.md
@@ -15,7 +15,7 @@ Understanding of the basics elements of the Admin:
 
 ### Prerequirements {#prerequirements}
 
-* Have completed [Workshop 1](certification_admin_ws1)
+* Have completed [Workshop 1](./certification_admin_ws1.md)
 
 
 # Workshop {#workshop}

--- a/docs/certification/basic_admin/certification_admin_ws3.md
+++ b/docs/certification/basic_admin/certification_admin_ws3.md
@@ -14,7 +14,7 @@ Understanding of the basics elements of the Admin:
 
 ### Prerequirements {#prerequirements}
 
-* Have completed [Workshop 2](certification_admin_ws2)
+* Have completed [Workshop 2](./certification_admin_ws2.md)
 
 
 # Workshop {#workshop}

--- a/docs/certification/basic_admin/certification_admin_ws4.md
+++ b/docs/certification/basic_admin/certification_admin_ws4.md
@@ -14,7 +14,7 @@ Understanding of the basics elements of the Admin:
 
 ### Prerequirements {#prerequirements}
 
-* Have completed [Workshop 2](certification_admin_ws2) and [Workshop 3](certification_admin_ws3) 
+* Have completed [Workshop 2](./certification_admin_ws2.md) and [Workshop 3](./certification_admin_ws3.md) 
 
 
 # Workshop {#workshop}

--- a/docs/certification/basic_admin/certification_admin_ws5.md
+++ b/docs/certification/basic_admin/certification_admin_ws5.md
@@ -14,7 +14,7 @@ Understanding of the basics elements of the Admin:
 
 ### Prerequirements {#prerequirements}
 
-* Have completed [Workshop 4](certification_admin_ws4)
+* Have completed [Workshop 4](./certification_admin_ws4.md)
 
 
 # Workshop {#workshop}

--- a/docs/certification/basic_admin/certification_admin_ws6.md
+++ b/docs/certification/basic_admin/certification_admin_ws6.md
@@ -16,7 +16,7 @@ Understanding of the basics elements of the Admin:
 
 ### Prerequirements {#prerequirements}
 
-* Have completed [Workshop 5](certification_admin_ws5)
+* Have completed [Workshop 5](./certification_admin_ws5.md)
 
 # Workshop {#workshop}
 

--- a/docs/documentation/admin/admin_accessrole.md
+++ b/docs/documentation/admin/admin_accessrole.md
@@ -28,7 +28,7 @@ As shown in the image below, from the _Access roles_ button in the _Administrati
 <img alt="access roles settings panel" className="img_sizing item shadow--tl" src={useBaseUrl('img/admin_accessroles_00.png')} />
 <br />
 
-_Icon descriptions can be found in the [Overview section](admin_overview)._
+_Icon descriptions can be found in the [Overview section](./admin_overview.md)._
 
 Checkboxes enable you to select from one to all _access roles_, so you can deactivate them together with just one click.
 
@@ -38,7 +38,7 @@ From the _Access roles_ settings panel, you can edit or create a single access r
 <img alt="edit or create" className="img_sizing item shadow--tl" src={useBaseUrl('img/admin_accessroles_01.png')}  />
 <br />
 
-_Button descriptions can be found in the [Overview section](admin_overview)._
+_Button descriptions can be found in the [Overview section](./admin_overview.md)._
 
 ### Field Descriptions
 

--- a/docs/documentation/sql_bi/overview.md
+++ b/docs/documentation/sql_bi/overview.md
@@ -23,7 +23,7 @@ Our software generates a **read-only SQL database** from the data stored in our 
 
 
 :::info Additional information
-- The exact [**data model**](model) varies from company to company but is basically based on _users_, _surveys_, _channels_,  _collections_ (databases), _tasks_, and _sessions_.
+- The exact [**data model**](./model.md) varies from company to company but is basically based on _users_, _surveys_, _channels_,  _collections_ (databases), _tasks_, and _sessions_.
 - For **enterprise plans**, it is possible to search the SQL Database from a third-party BI platform. _Contact your Cotalker sales representative for more information._
 :::
 

--- a/docs/products/workflows/notifications/surveys-report.md
+++ b/docs/products/workflows/notifications/surveys-report.md
@@ -55,7 +55,7 @@ _Once the form appears, proceed as follows:_
 
 
 :::info Next step
-Once the supervisor receives the notification, they have to validate the report with the [Validate Incident](surveys-validate) form.
+Once the supervisor receives the notification, they have to validate the report with the [Validate Incident](./surveys-validate.md) form.
 :::
 
 ---

--- a/docs/products/workflows/work_orders/components/_surveys-accept-wo.mdx
+++ b/docs/products/workflows/work_orders/components/_surveys-accept-wo.mdx
@@ -30,5 +30,5 @@ Contractors and technical teams can either accept or reject the work order. If a
 
 :::info Next steps
 - After accepting the work order, contractors can also submit the <a href={props.quotes}><b>New Quote</b></a> form. This form is tied to master data to help easily choose services and available materials, along with their costs and stocks, respectively.
-- Once the job has been completed, maintenance personnel can request to close the work order by submitting the [**Close Work Order**](surveys-close-wo) form.
+- Once the job has been completed, maintenance personnel can request to close the work order by submitting the [**Close Work Order**](../surveys-close-wo) form.
 :::

--- a/docs/products/workflows/work_orders/components/_surveys-acceptance.mdx
+++ b/docs/products/workflows/work_orders/components/_surveys-acceptance.mdx
@@ -30,6 +30,6 @@ The **Acceptance of Work** form allows supervisors to accept or reject a request
 <br/>
 
 :::info Next step
-Immediately after closing the workflow, supervisors can fill out the [**Feedback**](surveys-feedback) form that appears on the channel.
+Immediately after closing the workflow, supervisors can fill out the [**Feedback**](../surveys-feedback) form that appears on the channel.
 :::
 

--- a/docs/products/workflows/work_orders/components/_surveys-close-wo.mdx
+++ b/docs/products/workflows/work_orders/components/_surveys-close-wo.mdx
@@ -30,5 +30,5 @@ After submission, the workflow passes to the _validate_ state.
 <br/>
 
 :::info Next step
-Supervisors review the submitted **Close Work Order** and fill out the [**Acceptance of Work**](surveys-acceptance) form.
+Supervisors review the submitted **Close Work Order** and fill out the [**Acceptance of Work**](../surveys-acceptance) form.
 :::

--- a/docs/products/workflows/work_orders/components/_surveys-create-wo-cm.mdx
+++ b/docs/products/workflows/work_orders/components/_surveys-create-wo-cm.mdx
@@ -57,5 +57,5 @@ Once submitted, the _work order_ workflow initiates and is set to the first stat
 <br/>
 
 :::info Next Step
-After creating the work order, maintenance personnel review it and can choose to accept it or not with the [**Accept Work Order**](surveys-accept-wo) form.
+After creating the work order, maintenance personnel review it and can choose to accept it or not with the [**Accept Work Order**](../surveys-accept-wo) form.
 :::

--- a/docs/products/workflows/work_orders/components/_surveys-create-wo-wo.mdx
+++ b/docs/products/workflows/work_orders/components/_surveys-create-wo-wo.mdx
@@ -28,5 +28,5 @@ The form asks for detailed information concerning the maintenance task at hand. 
 
 
 :::info Next Step
-After creating the work order, maintenance personnel review it and can choose to accept it or not with the [**Accept Work Order**](surveys-accept-wo) form.
+After creating the work order, maintenance personnel review it and can choose to accept it or not with the [**Accept Work Order**](../surveys-accept-wo) form.
 :::

--- a/docs/products/workflows/work_orders/related-product/pm/surveys-checklist-pm.mdx
+++ b/docs/products/workflows/work_orders/related-product/pm/surveys-checklist-pm.mdx
@@ -34,5 +34,5 @@ The checklist's fields contain customizable options to select from.
 
 :::info next steps
 - During this part of the process, contractors can send a [quote](/docs/products/workflows/budget_management/related-product/pm/overview) for approval.
-- Once the maintenance job has been completed, personnel submit a form to request the [closure of the work order](surveys-close-wo).
+- Once the maintenance job has been completed, personnel submit a form to request the [closure of the work order](../surveys-close-wo).
 :::

--- a/docs/tutorials/basic/tutorial_configure_company.md
+++ b/docs/tutorials/basic/tutorial_configure_company.md
@@ -21,7 +21,7 @@ Time: 7 minutes
 
 ## Company Requirements {#company-requirements}
 
-As mentioned in the [Overview](../tutorial_overview), we will be working with a make-believe company called _Ruanda_ for this tutorial. The company's first requirements are described below:
+As mentioned in the [Overview](../tutorial_overview.md), we will be working with a make-believe company called _Ruanda_ for this tutorial. The company's first requirements are described below:
 
 - The company resides in Chile, but they work oversees, so its language preference should be set to English.
 

--- a/docs/tutorials/intermediate/tutorial_isCommanded.md
+++ b/docs/tutorials/intermediate/tutorial_isCommanded.md
@@ -20,7 +20,7 @@ We will now work to offer a dynamic survey, where the user's department will act
 * User with the `read admin` access role.
 
 #### Survey
-* Having completed the [Survey that Starts a Workflow Tutorial](create_survey_sm).
+* Having completed the [Survey that Starts a Workflow Tutorial](./tutorial_survey_sm.md).
 
 
 ## Steps {#steps}
@@ -37,7 +37,7 @@ We will now work to offer a dynamic survey, where the user's department will act
 2. Look for the **Task Creator** survey and open it.
 
 :::note
-This survey was created in the [Survey that Starts a Workflow Tutorial](create_survey_sm).
+This survey was created in the [Survey that Starts a Workflow Tutorial](./tutorial_survey_sm.md).
 :::
 
 </div>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,6 +23,9 @@ module.exports = {
         // acumula como error. Esto genera una página de redirección /es/<ruta>
         // por cada ruta actual, apuntando a la versión sin prefijo.
         createRedirects(existingPath) {
+          // Guard defensivo: hoy no existen rutas /es/ (i18n está deshabilitado
+          // más abajo), pero si se reactiva el locale este check evita generar
+          // redirects /es/es/* sobre las páginas reales en español
           if (existingPath.startsWith('/es/')) {
             return undefined;
           }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,6 +2,10 @@ module.exports = {
   title: 'Cotalker Technical Documentation',
   url: 'https://doc.cotalker.com',
   baseUrl: '/',
+  // El bucket S3 sirve carpetas con index.html y redirige (302) las URLs sin
+  // slash final; con trailingSlash el sitemap y los links internos apuntan
+  // directo a la versión canónica y Google deja de ver todo como redirección
+  trailingSlash: true,
   favicon: 'img/favicon.ico',
   organizationName: 'Cotalker', // Usually your GitHub org/user name.
   projectName: 'Cotalker', // Usually your repo name.
@@ -10,7 +14,22 @@ module.exports = {
   },
   themes: ['@docusaurus/theme-live-codeblock','@docusaurus/theme-mermaid'],
   plugins: [
-    require.resolve('docusaurus-lunr-search')
+    require.resolve('docusaurus-lunr-search'),
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        // El locale /es/ se deshabilitó y el deploy a S3 (--delete) borró esos
+        // archivos: las URLs legacy /es/* devuelven 403 y Search Console las
+        // acumula como error. Esto genera una página de redirección /es/<ruta>
+        // por cada ruta actual, apuntando a la versión sin prefijo.
+        createRedirects(existingPath) {
+          if (existingPath.startsWith('/es/')) {
+            return undefined;
+          }
+          return [`/es${existingPath}`];
+        },
+      },
+    ],
   ],
   themeConfig: {
     disableDark: 'light',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.0.0",
       "dependencies": {
         "@docusaurus/core": "^2.4.3",
+        "@docusaurus/plugin-client-redirects": "2.4.3",
         "@docusaurus/plugin-content-docs": "^2.4.3",
         "@docusaurus/preset-classic": "^2.4.3",
         "@docusaurus/theme-live-codeblock": "^2.4.3",
@@ -2572,6 +2573,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.3.tgz",
+      "integrity": "sha512-iCwc/zH8X6eNtLYdyUJFY6+GbsbRgMgvAC/TmSmCYTmwnoN5Y1Bc5OwUkdtoch0XKizotJMRAmGIAhP8sAetdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/logger": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
+        "@docusaurus/utils-common": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
+        "eta": "^2.0.0",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.3",
+    "@docusaurus/plugin-client-redirects": "2.4.3",
     "@docusaurus/plugin-content-docs": "^2.4.3",
     "@docusaurus/preset-classic": "^2.4.3",
     "@docusaurus/theme-live-codeblock": "^2.4.3",

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://doc.cotalker.com/sitemap.xml


### PR DESCRIPTION
## Contexto

Search Console (propiedad de dominio cotalker.com) acumula ~320 URLs de doc.cotalker.com con problemas: 46 con error 403, 271 "rastreada: actualmente sin indexar" y parte de las 108 "página con redirección". Diagnóstico contra el sitio en vivo:

1. **El sitemap emitía las 526 URLs sin slash final**, pero el bucket S3 sirve carpetas (`/ruta/index.html`) y responde **302** a las URLs sin slash → toda URL que Google tomaba del sitemap aterrizaba en una redirección, y la versión con slash quedaba como "sin indexar" por la señal contradictoria.
2. **`robots.txt` no existía** → S3 devuelve 403 (`AccessDenied`).
3. **El locale `/es/` se deshabilitó** (i18n comentado en `docusaurus.config.js`) y el deploy con `--delete` borró esos archivos del bucket → las ~300 URLs legacy `/es/docs/...` indexadas en su momento hoy devuelven **403** en vez de un redirect o 404.

## Cambios

- `trailingSlash: true` en `docusaurus.config.js`: sitemap, links internos y canonicals apuntan directo a la versión con slash que sirve S3 (verificado en el build: 526/526 URLs del sitemap con slash, canonical `https://doc.cotalker.com/.../` en las páginas).
- `static/robots.txt` con referencia al sitemap.
- `@docusaurus/plugin-client-redirects@2.4.3` (misma versión que el core): genera una página `/es/<ruta>` por cada ruta actual, con meta-refresh + canonical a la versión sin prefijo. Las URLs legacy `/es/*` pasan de 403 a resolverse hacia la página vigente.

## Validación

> **Corrección** (post-review): la validación original de este PR estaba mal — el build en realidad fallaba por broken links (el exit code quedó enmascarado por un pipe a `tail`, y los artefactos de `build/` que se inspeccionaron se escribieron antes de que el chequeo abortara). Los reviewers tenían razón. Corregido en `da6231f`.

Validación actual (commit `da6231f`): `rm -rf build .docusaurus && npm run build` → `[SUCCESS]`, **exit 0 real** (sin pipe), 0 broken links, en Docusaurus 2.4.3 + Node 22 (CI usa Node 18, ambos soportados). Verificado en `build/`: sitemap con las 526 URLs con slash final, hrefs de los links corregidos apuntando a los hermanos correctos (spot-check en certification, work_orders/cm, tutoriales), `build/es/docs/documentation/admin/admin_scheduler/index.html` (URL reportada con 403 en GSC) existe y redirige con canonical, `build/robots.txt` presente.

## Notas

- El merge a `main` despliega automáticamente a S3 (workflow `nodejs.yml`).
- Queda un pendiente de infra (fuera de este repo): el bucket devuelve 403 en vez de 404 para rutas inexistentes porque el rol público no tiene `s3:ListBucket`. Con estos cambios las URLs conocidas dejan de caer ahí, pero un 404 real seguiría respondiendo 403.
- Tras el deploy: en Search Console, "Validar corrección" en los buckets de 403 y reenviar el sitemap de doc.cotalker.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
